### PR TITLE
Add OCI Referrers API support and fix ACR auth

### DIFF
--- a/specs/cli/referrer.md
+++ b/specs/cli/referrer.md
@@ -1,0 +1,180 @@
+# CLI: `referrer`
+
+## Overview
+
+The `referrer` command group discovers OCI referrers (supply-chain artifacts
+such as SBOMs, signatures, and attestations) linked to a manifest via the
+OCI Referrers API.
+
+| Subcommand | Method | Endpoint |
+|---|---|---|
+| `list` | `GET` | `/v2/<name>/referrers/<digest>[?artifactType=<type>]` |
+
+> **Note:** The referrers endpoint is read-only — referrers are created
+> implicitly when a manifest with a `subject` field is pushed via
+> `manifest put`. No `create` or `delete` subcommand is needed.
+
+---
+
+## Usage
+
+```
+regshape referrer list [OPTIONS]
+```
+
+---
+
+## Image Reference Format
+
+The `referrer list` subcommand accepts `--image-ref` / `-i` using the standard
+container image reference syntax with the registry always embedded. The
+reference **must** include a digest — tag-only references are rejected because
+the referrers API requires a digest.
+
+| Subcommand | Accepted formats | Notes |
+|---|---|---|
+| `list` | `registry/repo@sha256:...` | Digest is required |
+
+> **Authentication:** Run `regshape auth login` before using referrer commands
+> against authenticated registries. Credentials are resolved automatically
+> from the Docker credential store. Commands return exit code 1 with an
+> authentication error if no stored credentials exist for the registry.
+
+---
+
+## Subcommands
+
+### `referrer list`
+
+List all referrers for the manifest identified by digest in IMAGE_REF.
+
+#### Options
+
+| Option | Short | Type | Default | Description |
+|---|---|---|---|---|
+| `--image-ref` | `-i` | string | required | Image reference with embedded registry and digest (e.g., `registry/repo@sha256:abc...`) |
+| `--artifact-type` | `-t` | string | none | Filter referrers to this artifact type (e.g., `application/vnd.example.sbom.v1`) |
+| `--all` | | flag | false | Follow pagination and return all referrers (default: single page only) |
+| `--json` | | flag | false | Output the full `ReferrerList` JSON object instead of one referrer per line |
+| `--output` | `-o` | path | stdout | Write output to this file instead of stdout |
+| `--time-methods` | | flag | false | Print execution time for individual method calls |
+| `--time-scenarios` | | flag | false | Print execution time for multi-step workflows |
+| `--debug-calls` | | flag | false | Print request/response headers for each HTTP call |
+
+#### Behavior
+
+1. Parse `--image-ref` to extract registry, repository, and digest. Reject
+   tag-only references with exit code 2 and an error message directing the
+   user to use a digest reference.
+2. Resolve credentials from the Docker credential store for the extracted
+   registry.
+3. If `--all` is set, call `list_referrers_all()` which follows `Link`
+   pagination headers to retrieve every page and returns a merged
+   `ReferrerList`. Otherwise, call `list_referrers()` which returns a
+   single page.
+4. Parse the response body into a `ReferrerList` model.
+5. If `--artifact-type` was provided but the registry did not apply
+   server-side filtering (missing `OCI-Filters-Applied` header), the
+   operations layer performs client-side filtering transparently.
+6. If `--json` is set, print the full Image Index JSON object. Otherwise,
+   print one referrer per line in the format:
+   ```
+   <digest> <artifactType> <size>
+   ```
+   This tabular format is suitable for scripting with `awk`, `grep`, etc.
+7. If `--output` is given, write to that file instead of stdout.
+
+#### Exit Codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success (including when there are zero referrers) |
+| 1 | HTTP error (manifest not found, auth failure, connection error) |
+| 2 | Invalid reference (tag-only reference instead of digest) |
+
+#### Examples
+
+```bash
+# Log in first
+regshape auth login -r acr.io -u alice
+
+# List all referrers for a manifest by digest (single page)
+regshape referrer list -i acr.io/myrepo/myimage@sha256:abc123...
+
+# List all referrers across all pages
+regshape referrer list -i acr.io/myrepo/myimage@sha256:abc123... --all
+
+# Filter referrers by artifact type (only SBOMs)
+regshape referrer list -i acr.io/myrepo/myimage@sha256:abc123... \
+    --artifact-type application/vnd.example.sbom.v1
+
+# Output as JSON
+regshape referrer list -i acr.io/myrepo/myimage@sha256:abc123... --json
+
+# Save referrer list to a file
+regshape referrer list -i acr.io/myrepo/myimage@sha256:abc123... -o referrers.txt
+
+# Combine with tools — count signatures
+regshape referrer list -i acr.io/myrepo/myimage@sha256:abc123... \
+    --artifact-type application/vnd.cncf.notary.signature | wc -l
+```
+
+---
+
+## Output Format
+
+### Plain text (default)
+
+One referrer per line with digest, artifact type, and size:
+
+```
+sha256:a1b2c3d4e5f6... application/vnd.example.sbom.v1 1234
+sha256:f6e5d4c3b2a1... application/vnd.cncf.notary.signature 567
+```
+
+When no referrers exist, output is empty (no output, exit code 0).
+
+### JSON (`--json`)
+
+Full OCI Image Index response:
+
+```json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:a1b2c3d4e5f6...",
+      "size": 1234,
+      "artifactType": "application/vnd.example.sbom.v1",
+      "annotations": {
+        "org.opencontainers.image.created": "2025-06-15T10:30:00Z"
+      }
+    }
+  ]
+}
+```
+
+---
+
+## Error Messages
+
+| Scenario | Message | Exit Code |
+|----------|---------|-----------|
+| Tag-only reference | `Error [<ref>]: referrer list requires a digest reference (registry/repo@sha256:...); use 'manifest get' to resolve a tag to a digest` | 2 |
+| Auth failure | `Error [<ref>]: Authentication failed for <registry>: <detail>` | 1 |
+| Manifest not found | `Error [<ref>]: Manifest not found: <registry>/<repo>@<digest>` | 1 |
+| Connection error | `Error [<ref>]: <exception message>` | 1 |
+
+---
+
+## Registration
+
+The `referrer` command group is registered in `src/regshape/cli/main.py`:
+
+```python
+from regshape.cli.referrer import referrer
+
+regshape.add_command(referrer)
+```

--- a/specs/models/referrer.md
+++ b/specs/models/referrer.md
@@ -1,0 +1,188 @@
+# Data Model: Referrer
+
+## Overview
+
+This spec defines the data model for OCI referrers responses in
+`src/regshape/libs/models/referrer.py`.
+
+The OCI Referrers API returns an Image Index whose `manifests` array
+contains descriptors for all manifests that reference a given subject
+digest via their `subject` field. Each descriptor carries an
+`artifactType` and optional `annotations` that describe the type
+of supply-chain artifact (SBOM, signature, attestation, etc.).
+
+The response is an OCI Image Index with `schemaVersion: 2` and
+`mediaType: application/vnd.oci.image.index.v1+json`. The `manifests`
+array uses standard OCI content descriptors, each of which may include
+`artifactType` and `annotations`.
+
+---
+
+## Module Structure
+
+```
+src/regshape/libs/models/
+├── __init__.py        # Updated: exports ReferrerList
+├── blob.py
+├── catalog.py
+├── descriptor.py      # Existing: Descriptor, Platform (reused)
+├── error.py
+├── manifest.py
+├── mediatype.py
+├── referrer.py        # NEW: ReferrerList
+└── tags.py
+```
+
+`ReferrerError` is added to `src/regshape/libs/errors.py`, parallel to
+`TagError`, `BlobError`, and `CatalogError`.
+
+---
+
+## Data Models
+
+### `ReferrerList`
+
+Represents the response body of `GET /v2/<name>/referrers/<digest>`.
+
+```python
+@dataclass
+class ReferrerList:
+    manifests: list[Descriptor]  # Wire key: "manifests"
+```
+
+#### Field notes
+
+- **`manifests`** is a list of OCI content descriptors, each representing a
+  manifest that has a `subject` field pointing to the queried digest. The
+  existing `Descriptor` dataclass already supports the `artifact_type` and
+  `annotations` fields needed for referrer entries.
+- A registry MAY return an empty `manifests` array (`[]`) when the subject
+  has no referrers. `from_dict` normalises `null` or missing `"manifests"`
+  to `[]`.
+- Each descriptor in the `manifests` array typically includes:
+  - `mediaType` — usually `application/vnd.oci.image.manifest.v1+json`
+  - `digest` — digest of the referring manifest
+  - `size` — size of the referring manifest
+  - `artifactType` — media type describing the artifact kind
+  - `annotations` — optional key-value metadata
+
+#### Validation rules (`__post_init__`)
+
+| Field | Rule | Error |
+|-------|------|-------|
+| `manifests` | Must be a `list` | `ValueError` |
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `to_dict` | `() -> dict` | Serializes to OCI wire dict (Image Index format) |
+| `to_json` | `() -> str` | Canonical JSON (`sort_keys=True`, compact separators) |
+| `from_dict` | `(cls, data: object) -> ReferrerList` | Deserializes from wire dict; normalises `null`/missing manifests |
+| `from_json` | `(cls, data: str) -> ReferrerList` | Deserializes from raw JSON string |
+| `filter_by_artifact_type` | `(self, artifact_type: str) -> ReferrerList` | Returns a new `ReferrerList` containing only descriptors matching the given artifact type |
+| `merge` | `(self, other: ReferrerList) -> ReferrerList` | Returns a new `ReferrerList` with manifests from both lists concatenated (used for pagination accumulation) |
+
+---
+
+## JSON Wire Format
+
+### Normal response (with referrers)
+
+```json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:a1b2c3d4e5f6...",
+      "size": 1234,
+      "artifactType": "application/vnd.example.sbom.v1",
+      "annotations": {
+        "org.opencontainers.image.created": "2025-06-15T10:30:00Z"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:f6e5d4c3b2a1...",
+      "size": 567,
+      "artifactType": "application/vnd.cncf.notary.signature",
+      "annotations": {}
+    }
+  ]
+}
+```
+
+### Empty response (no referrers)
+
+```json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": []
+}
+```
+
+---
+
+## Serialization
+
+### `to_dict`
+
+Always emits the full Image Index envelope:
+
+```python
+{
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.oci.image.index.v1+json",
+    "manifests": [descriptor.to_dict() for descriptor in self.manifests],
+}
+```
+
+### `from_dict`
+
+1. Validate that *data* is a `dict`; raise `ReferrerError` otherwise.
+2. Extract `"manifests"` key; normalise `null` / missing to `[]`.
+3. Deserialize each entry via `Descriptor.from_dict()`.
+4. Return `ReferrerList(manifests=descriptors)`.
+
+The method intentionally ignores `schemaVersion` and `mediaType` from the
+response body — these are fixed values for the referrers endpoint and the
+OCI spec does not define meaningful variations to branch on.
+
+### `from_json`
+
+1. Parse JSON string via `json.loads()`.
+2. Delegate to `from_dict`.
+3. Wrap `json.JSONDecodeError` in `ReferrerError`.
+
+---
+
+## Relationships
+
+- **`Descriptor`** (existing): Each entry in `manifests` is deserialized as
+  an existing `Descriptor` instance. The `artifact_type` and `annotations`
+  fields on `Descriptor` carry the referrer-specific metadata.
+- **`ImageIndex`** (existing): The wire format is an OCI Image Index, but
+  `ReferrerList` is a distinct type because:
+  - It is read-only (registries generate it; clients never push it).
+  - It does not carry `platform` data on descriptors.
+  - It benefits from a `filter_by_artifact_type` method.
+  - Keeping it separate avoids overloading `ImageIndex` with referrer-specific logic.
+
+---
+
+## Error Types
+
+### `ReferrerError`
+
+Added to `src/regshape/libs/errors.py`:
+
+```python
+class ReferrerError(RegShapeError):
+    """
+    Error caused by a malformed or unprocessable referrers response.
+    """
+    pass
+```

--- a/specs/operations/referrers.md
+++ b/specs/operations/referrers.md
@@ -172,7 +172,7 @@ full relative URL path (including query string) for the next page.
 | Header present with `rel="next"` | Relative URL string for next page |
 | Header absent or no `rel="next"` | `None` |
 
-This follows the same pattern as `catalog.operations._parse_next_cursor`.
+This follows the same pattern as `catalog.operations._parse_next_url`.
 
 ---
 

--- a/specs/operations/referrers.md
+++ b/specs/operations/referrers.md
@@ -217,15 +217,9 @@ the first 200 characters of `response.text`.
 - `regshape.libs.errors` — `AuthError`, `ReferrerError` (new)
 - `regshape.libs.models.referrer` — `ReferrerList` (new)
 - `regshape.libs.models.error` — `OciErrorResponse`
-- `regshape.libs.refs` — `format_ref`
 - `regshape.libs.transport` — `RegistryClient`
 - `regshape.libs.decorators.timing` — `track_time`
 - `regshape.libs.decorators.scenario` — `track_scenario`
-
-**External:**
-- `requests` — `requests.Response` type annotation only
-
----
 
 **External:**
 - `requests` — `requests.Response` type annotation only

--- a/specs/operations/referrers.md
+++ b/specs/operations/referrers.md
@@ -1,0 +1,233 @@
+# Operations: Referrers
+
+## Overview
+
+This spec documents the domain operations layer for OCI referrers interactions
+in `src/regshape/libs/referrers/operations.py`.
+
+The OCI Referrers API (`GET /v2/<name>/referrers/<digest>`) returns an Image
+Index whose `manifests` array lists all manifests that have a `subject` field
+pointing to the given digest. This is the primary mechanism for discovering
+supply-chain artifacts (SBOMs, signatures, attestations, etc.) attached to an
+image.
+
+The referrers operations layer sits between the CLI and the transport layer.
+It never calls `requests` directly — all HTTP traffic goes through a
+`RegistryClient` instance provided by the caller.
+
+### Endpoints
+
+| Operation | Method | Endpoint |
+|---|---|---|
+| List referrers (single page) | `GET` | `/v2/{repo}/referrers/{digest}[?artifactType=<type>]` |
+| List referrers (all pages) | `GET` | `/v2/{repo}/referrers/{digest}[?artifactType=<type>]` (follows `Link` headers) |
+
+---
+
+## Module Structure
+
+```
+src/regshape/libs/referrers/
+├── __init__.py        # Package init; re-exports public symbols
+└── operations.py      # Public domain operations + private error helpers
+```
+
+---
+
+## Public Operations
+
+### `list_referrers`
+
+```python
+@track_time
+def list_referrers(
+    client: RegistryClient,
+    repo: str,
+    digest: str,
+    artifact_type: Optional[str] = None,
+) -> ReferrerList:
+```
+
+Fetches the list of referrers for the manifest identified by *digest* in
+*repo*.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `client` | `RegistryClient` | required | Authenticated transport client |
+| `repo` | `str` | required | Repository name (e.g. `"myrepo/myimage"`) |
+| `digest` | `str` | required | Manifest digest in `algorithm:hex` form (e.g. `sha256:abc123...`) |
+| `artifact_type` | `Optional[str]` | `None` | Filter results to this artifact type; omitted when `None` |
+
+**Returns:** `ReferrerList`
+
+**Behaviour:**
+
+1. Build path `"/v2/{repo}/referrers/{digest}"`.
+2. Append `?artifactType=<artifact_type>` when provided.
+3. Call `client.get(path, params=params)`.
+4. Pass response to `_raise_for_list_error`.
+5. Check the `OCI-Filters-Applied` response header. If `artifactType` was
+   requested but the header is absent, perform client-side filtering on the
+   deserialized `ReferrerList.manifests` array (keep only entries where
+   `Descriptor.artifact_type` matches the requested value).
+6. Deserialize and return `ReferrerList.from_json(response.text)`.
+   Re-raises `ReferrerError` directly; wraps all other exceptions in
+   `ReferrerError`.
+
+**Decorator:** `@track_time`
+
+---
+
+### `list_referrers_all`
+
+```python
+@track_scenario("referrer list all")
+def list_referrers_all(
+    client: RegistryClient,
+    repo: str,
+    digest: str,
+    artifact_type: Optional[str] = None,
+) -> ReferrerList:
+```
+
+Fetches all pages of the referrer list and returns them merged into a single
+`ReferrerList`.
+
+Follows `Link: rel="next"` response headers until all pages have been
+retrieved, then returns a single `ReferrerList` whose `manifests` list is
+the ordered concatenation of every page.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `client` | `RegistryClient` | required | Authenticated transport client |
+| `repo` | `str` | required | Repository name (e.g. `"myrepo/myimage"`) |
+| `digest` | `str` | required | Manifest digest in `algorithm:hex` form |
+| `artifact_type` | `Optional[str]` | `None` | Filter results to this artifact type; omitted when `None` |
+
+**Returns:** `ReferrerList` — merged result containing all referrers across
+all pages.
+
+**Behaviour:**
+
+1. Call `list_referrers(client, repo, digest, artifact_type)` to fetch the
+   first page.
+2. Accumulate `page.manifests` into a running list.
+3. Inspect the `Link` header from `client.last_response` using
+   `_parse_next_cursor()`.
+4. If a next-page cursor is found, issue `client.get()` with the extracted
+   URL and repeat from step 2.
+5. When no `Link: rel="next"` header is present, merge all accumulated
+   descriptors into a single `ReferrerList` and return it.
+6. Client-side `artifactType` filtering (see below) is applied once on
+   the final merged result, not per-page, to avoid redundant work.
+
+**Decorator:** `@track_scenario("referrer list all")`
+
+**Note:** The first page is fetched via `list_referrers()` (which has
+`@track_time`). Subsequent pages are fetched with direct `client.get()`
+calls to avoid double-timing. The overall multi-page operation is timed
+by the `@track_scenario` decorator.
+
+---
+
+### Client-Side Filtering
+
+The OCI Distribution Spec defines the `artifactType` query parameter and the
+`OCI-Filters-Applied` response header. Registries that support server-side
+filtering include `OCI-Filters-Applied: artifactType` in their response.
+Registries that do not support server-side filtering return the full unfiltered
+list without the header.
+
+The operations layer handles both cases transparently:
+
+1. Always pass `artifactType` as a query parameter when the caller provides it.
+2. On response, inspect the `OCI-Filters-Applied` header:
+   - **Present and contains `artifactType`**: Trust the response — server
+     already filtered.
+   - **Absent or does not contain `artifactType`**: Apply client-side
+     filtering — iterate `ReferrerList.manifests` and retain only descriptors
+     where `descriptor.artifact_type == artifact_type`.
+
+This ensures correct behaviour across all registry implementations.
+
+---
+
+## Private Helpers
+
+### `_parse_next_cursor`
+
+Parses the OCI `Link` response header and returns the URL for the next page.
+
+The OCI pagination `Link` header format is:
+
+```
+Link: </v2/<name>/referrers/<digest>?n=100&last=sha256:abc...>; rel="next"
+```
+
+Extracts the URL inside `<...>`, checks for `rel="next"`, and returns the
+full relative URL path (including query string) for the next page.
+
+| Input | Output |
+|---|---|
+| Header present with `rel="next"` | Relative URL string for next page |
+| Header absent or no `rel="next"` | `None` |
+
+This follows the same pattern as `catalog.operations._parse_next_cursor`.
+
+---
+
+### `_raise_for_list_error`
+
+| HTTP status | Exception | Message |
+|---|---|---|
+| `401` | `AuthError` | `"Authentication failed for {registry}"` |
+| `404` | `ReferrerError` | `"Manifest not found: {registry}/{repo}@{digest}"` |
+| other non-2xx | `ReferrerError` | `"Registry error for {registry}/{repo}@{digest}: HTTP {status}"` |
+
+The helper populates the `detail` field from
+`OciErrorResponse.from_response(response).first_detail()`, falling back to
+the first 200 characters of `response.text`.
+
+---
+
+## Telemetry
+
+| Decorator | Applied to |
+|---|---|
+| `@track_time` | `list_referrers` |
+| `@track_scenario("referrer list all")` | `list_referrers_all` |
+
+---
+
+## Error Handling Summary
+
+| Condition | Exception | Raised by |
+|---|---|---|
+| `401` on list | `AuthError` | `_raise_for_list_error` |
+| `404` on list | `ReferrerError` "Manifest not found" | `_raise_for_list_error` |
+| Other non-2xx | `ReferrerError` generic | `_raise_for_list_error` |
+| Malformed JSON body | `ReferrerError` | `ReferrerList.from_json` (re-raised) |
+| Transport / connection failure | `requests.exceptions.RequestException` | propagated as-is |
+
+---
+
+## Dependencies
+
+**Internal:**
+- `regshape.libs.errors` — `AuthError`, `ReferrerError` (new)
+- `regshape.libs.models.referrer` — `ReferrerList` (new)
+- `regshape.libs.models.error` — `OciErrorResponse`
+- `regshape.libs.refs` — `format_ref`
+- `regshape.libs.transport` — `RegistryClient`
+- `regshape.libs.decorators.timing` — `track_time`
+- `regshape.libs.decorators.scenario` — `track_scenario`
+
+**External:**
+- `requests` — `requests.Response` type annotation only
+
+---
+
+**External:**
+- `requests` — `requests.Response` type annotation only
+- `re` — regex for `Link` header parsing
+- `urllib.parse` — `urlparse`, `parse_qs` for cursor extraction

--- a/src/regshape/cli/main.py
+++ b/src/regshape/cli/main.py
@@ -18,6 +18,7 @@ from regshape.cli.auth import auth
 from regshape.cli.blob import blob
 from regshape.cli.catalog import catalog
 from regshape.cli.manifest import manifest
+from regshape.cli.referrer import referrer
 from regshape.cli.tag import tag
 
 
@@ -67,6 +68,7 @@ regshape.add_command(auth)
 regshape.add_command(blob)
 regshape.add_command(catalog)
 regshape.add_command(manifest)
+regshape.add_command(referrer)
 regshape.add_command(tag)
 
 

--- a/src/regshape/cli/referrer.py
+++ b/src/regshape/cli/referrer.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+
+"""
+:mod:`regshape.cli.referrer` - CLI commands for OCI referrer operations
+========================================================================
+
+.. module:: regshape.cli.referrer
+   :platform: Unix, Windows
+   :synopsis: Click command group providing the ``list`` subcommand for
+              OCI referrer operations.
+
+.. moduleauthor:: ToddySM <toddysm@gmail.com>
+"""
+
+import json
+import sys
+from typing import Optional
+
+import click
+import requests
+
+from regshape.libs.decorators import telemetry_options
+from regshape.libs.decorators.scenario import track_scenario
+from regshape.libs.errors import AuthError, ReferrerError
+from regshape.libs.refs import parse_image_ref
+from regshape.libs.referrers import list_referrers, list_referrers_all
+from regshape.libs.transport import RegistryClient, TransportConfig
+
+
+# ===========================================================================
+# Public Click group
+# ===========================================================================
+
+@click.group()
+def referrer():
+    """Discover OCI referrers (SBOMs, signatures, attestations)."""
+    pass
+
+
+# ===========================================================================
+# referrer list
+# ===========================================================================
+
+@referrer.command("list")
+@telemetry_options
+@click.option(
+    "--image-ref",
+    "-i",
+    required=True,
+    metavar="IMAGE_REF",
+    help=(
+        "Image reference with embedded registry and digest "
+        "(e.g. registry/repo@sha256:abc...). "
+        "Tag-only references are rejected — a digest is required."
+    ),
+)
+@click.option(
+    "--artifact-type",
+    "-t",
+    default=None,
+    metavar="TYPE",
+    help=(
+        "Filter referrers to this artifact type "
+        "(e.g. application/vnd.example.sbom.v1)."
+    ),
+)
+@click.option(
+    "--all",
+    "fetch_all",
+    is_flag=True,
+    default=False,
+    help="Follow pagination and return all referrers (default: single page only).",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output the full ReferrerList as a JSON object instead of one referrer per line.",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    default=None,
+    help="Write output to this file instead of stdout.",
+)
+@click.pass_context
+@track_scenario("referrer list")
+def referrer_list(ctx, image_ref, artifact_type, fetch_all, as_json, output):
+    """List referrers for the manifest identified by digest in IMAGE_REF.
+
+    IMAGE_REF must embed the registry and use a digest reference
+    (``registry/repo@sha256:...``). Tag-only references are rejected —
+    use ``manifest get`` to resolve a tag to a digest first.
+
+    Use ``--artifact-type`` to filter by artifact type.  Use ``--all``
+    to follow pagination and retrieve every referrer.  Use ``--json``
+    to receive the full Image Index object instead of one referrer per line.
+    """
+    insecure = ctx.obj.get("insecure", False) if ctx.obj else False
+
+    try:
+        registry, repo, reference = parse_image_ref(image_ref)
+    except ValueError as exc:
+        _error(image_ref, str(exc))
+        sys.exit(1)
+
+    # The referrers API requires a digest reference.
+    if not reference.startswith("sha256:") and not reference.startswith("sha512:"):
+        _error(
+            image_ref,
+            "referrer list requires a digest reference "
+            "(registry/repo@sha256:...); "
+            "use 'manifest get' to resolve a tag to a digest",
+        )
+        sys.exit(2)
+
+    client = RegistryClient(TransportConfig(registry=registry, insecure=insecure))
+
+    try:
+        if fetch_all:
+            result = list_referrers_all(
+                client=client,
+                repo=repo,
+                digest=reference,
+                artifact_type=artifact_type,
+            )
+        else:
+            result = list_referrers(
+                client=client,
+                repo=repo,
+                digest=reference,
+                artifact_type=artifact_type,
+            )
+    except (AuthError, ReferrerError, requests.exceptions.RequestException) as exc:
+        _error(image_ref, str(exc))
+        sys.exit(1)
+
+    if as_json:
+        _write(output, json.dumps(result.to_dict(), indent=2))
+    else:
+        lines = [
+            f"{d.digest} {d.artifact_type or ''} {d.size}"
+            for d in result.manifests
+        ]
+        _write(output, "\n".join(lines))
+
+
+# ===========================================================================
+# Internal helpers — output and error
+# ===========================================================================
+
+def _write(output_path: Optional[str], content: str) -> None:
+    """Write *content* to a file or stdout.
+
+    :param output_path: File path, or ``None`` to write to stdout.
+    :param content: Text to write.
+    """
+    if output_path:
+        with open(output_path, "w", encoding="utf-8") as fh:
+            fh.write(content)
+            if not content.endswith("\n"):
+                fh.write("\n")
+    else:
+        click.echo(content)
+
+
+def _error(reference: str, reason: str) -> None:
+    """Print an error message to stderr, prefixed with the reference."""
+    click.echo(f"Error [{reference}]: {reason}", err=True)

--- a/src/regshape/libs/errors.py
+++ b/src/regshape/libs/errors.py
@@ -66,3 +66,10 @@ class CatalogNotSupportedError(CatalogError):
     distinguish "endpoint not available" from "response was malformed".
     """
     pass
+
+
+class ReferrerError(RegShapeError):
+    """
+    Error caused by a malformed or unprocessable referrers response.
+    """
+    pass

--- a/src/regshape/libs/models/__init__.py
+++ b/src/regshape/libs/models/__init__.py
@@ -5,6 +5,7 @@ from regshape.libs.models.catalog import RepositoryCatalog
 from regshape.libs.models.descriptor import Descriptor, Platform
 from regshape.libs.models.error import OciErrorDetail, OciErrorResponse
 from regshape.libs.models.manifest import ImageManifest, ImageIndex, parse_manifest
+from regshape.libs.models.referrer import ReferrerList
 from regshape.libs.models.tags import TagList
 from regshape.libs.models import mediatype
 
@@ -19,6 +20,7 @@ __all__ = [
     'ImageManifest',
     'ImageIndex',
     'parse_manifest',
+    'ReferrerList',
     'TagList',
     'mediatype',
 ]

--- a/src/regshape/libs/models/referrer.py
+++ b/src/regshape/libs/models/referrer.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+"""
+:mod:`regshape.libs.models.referrer` - OCI ReferrerList data model
+===================================================================
+
+.. module:: regshape.libs.models.referrer
+   :platform: Unix, Windows
+   :synopsis: Dataclass for the OCI referrers response returned by
+              ``GET /v2/<name>/referrers/<digest>``.
+
+.. moduleauthor:: ToddySM <toddysm@gmail.com>
+"""
+
+import json
+from dataclasses import dataclass
+
+from regshape.libs.errors import ReferrerError
+from regshape.libs.models.descriptor import Descriptor
+
+
+@dataclass
+class ReferrerList:
+    """OCI referrers response.
+
+    Represents the JSON body returned by ``GET /v2/<name>/referrers/<digest>``.
+    The wire format is an OCI Image Index with ``schemaVersion: 2`` and
+    ``mediaType: application/vnd.oci.image.index.v1+json``.
+
+    :param manifests: List of :class:`~regshape.libs.models.descriptor.Descriptor`
+        instances, each representing a manifest that has a ``subject`` field
+        pointing to the queried digest.
+    """
+
+    manifests: list[Descriptor]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.manifests, list):
+            raise ValueError("ReferrerList.manifests must be a list")
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        """Serialize to an OCI wire-format dict (Image Index envelope).
+
+        Always emits ``"manifests": []`` rather than omitting the key when
+        the list is empty.
+
+        :returns: Dict ready for JSON serialization.
+        """
+        return {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [d.to_dict() for d in self.manifests],
+        }
+
+    def to_json(self) -> str:
+        """Serialize to a canonical JSON string.
+
+        Uses ``sort_keys=True`` and compact separators for deterministic
+        output.
+
+        :returns: Canonical JSON string.
+        """
+        return json.dumps(self.to_dict(), separators=(",", ":"), sort_keys=True)
+
+    # ------------------------------------------------------------------
+    # Deserialization
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_dict(cls, data: object) -> "ReferrerList":
+        """Deserialize from an OCI wire-format dict.
+
+        Normalises ``"manifests": null`` and a missing ``"manifests"`` key
+        to an empty list.  The ``schemaVersion`` and ``mediaType`` fields
+        are intentionally ignored — they are fixed values for the referrers
+        endpoint.
+
+        :param data: Dict parsed from a referrers JSON response.
+        :returns: A :class:`ReferrerList` instance.
+        :raises ReferrerError: If *data* is not a dict or descriptor
+            deserialization fails.
+        """
+        if not isinstance(data, dict):
+            raise ReferrerError(
+                "Invalid referrers response",
+                f"expected a dict, got {type(data).__name__!r}",
+            )
+        raw_manifests = data.get("manifests")
+        if raw_manifests is None:
+            manifests: list[Descriptor] = []
+        else:
+            if not isinstance(raw_manifests, list):
+                raise ReferrerError(
+                    "Invalid referrers response",
+                    f"'manifests' must be a list, got {type(raw_manifests).__name__!r}",
+                )
+            try:
+                manifests = [Descriptor.from_dict(entry) for entry in raw_manifests]
+            except (ValueError, TypeError) as exc:
+                raise ReferrerError(
+                    "Invalid referrers response",
+                    f"failed to parse descriptor: {exc}",
+                ) from exc
+        return cls(manifests=manifests)
+
+    @classmethod
+    def from_json(cls, data: str) -> "ReferrerList":
+        """Deserialize from a raw JSON string.
+
+        :param data: Raw JSON string from a ``GET /v2/<name>/referrers/<digest>``
+            response body.
+        :returns: A :class:`ReferrerList` instance.
+        :raises ReferrerError: If the JSON is malformed or required fields are
+            missing.
+        """
+        try:
+            obj = json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise ReferrerError(
+                "Failed to parse referrers JSON", str(exc)
+            ) from exc
+        return cls.from_dict(obj)
+
+    # ------------------------------------------------------------------
+    # Filtering and merging
+    # ------------------------------------------------------------------
+
+    def filter_by_artifact_type(self, artifact_type: str) -> "ReferrerList":
+        """Return a new :class:`ReferrerList` containing only descriptors
+        whose :attr:`~Descriptor.artifact_type` matches *artifact_type*.
+
+        :param artifact_type: The artifact type media type to filter on.
+        :returns: A new :class:`ReferrerList` with matching descriptors only.
+        """
+        return ReferrerList(
+            manifests=[
+                d for d in self.manifests if d.artifact_type == artifact_type
+            ]
+        )
+
+    def merge(self, other: "ReferrerList") -> "ReferrerList":
+        """Return a new :class:`ReferrerList` with manifests from both lists
+        concatenated.
+
+        Used during pagination to accumulate results across pages.
+
+        :param other: Another :class:`ReferrerList` to merge with.
+        :returns: A new :class:`ReferrerList` with combined manifests.
+        """
+        return ReferrerList(manifests=self.manifests + other.manifests)

--- a/src/regshape/libs/referrers/__init__.py
+++ b/src/regshape/libs/referrers/__init__.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+"""
+:mod:`regshape.libs.referrers` - Domain operations for OCI referrers
+=====================================================================
+
+.. module:: regshape.libs.referrers
+   :platform: Unix, Windows
+   :synopsis: Library-level functions for OCI referrer operations.
+
+.. moduleauthor:: ToddySM <toddysm@gmail.com>
+"""
+
+from regshape.libs.referrers.operations import (
+    list_referrers,
+    list_referrers_all,
+)
+
+__all__ = [
+    "list_referrers",
+    "list_referrers_all",
+]

--- a/src/regshape/libs/referrers/operations.py
+++ b/src/regshape/libs/referrers/operations.py
@@ -107,7 +107,8 @@ def list_referrers_all(
     list is the ordered concatenation of every page.
 
     Client-side ``artifactType`` filtering is applied once on the final
-    merged result, not per-page.
+    merged result after all pages have been collected, ensuring pages
+    fetched via bare ``Link``-header URLs are also filtered.
 
     :param client: Authenticated transport client for the target registry.
     :param repo: Repository name (e.g. ``myrepo/myimage``).
@@ -144,6 +145,12 @@ def list_referrers_all(
             ) from exc
 
         accumulated = accumulated.merge(page)
+
+    # Client-side filtering on the final merged result when the server did
+    # not apply server-side filtering.  The first page is already filtered
+    # by list_referrers(), but subsequent pages fetched via bare GET are not.
+    if artifact_type is not None:
+        accumulated = accumulated.filter_by_artifact_type(artifact_type)
 
     return accumulated
 

--- a/src/regshape/libs/referrers/operations.py
+++ b/src/regshape/libs/referrers/operations.py
@@ -19,7 +19,6 @@ concerns — error reporting is the caller's responsibility.
 
 import re
 from typing import Optional
-from urllib.parse import parse_qs, urlparse
 
 import requests
 

--- a/src/regshape/libs/referrers/operations.py
+++ b/src/regshape/libs/referrers/operations.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+
+"""
+:mod:`regshape.libs.referrers.operations` - OCI referrer operations
+====================================================================
+
+.. module:: regshape.libs.referrers.operations
+   :platform: Unix, Windows
+   :synopsis: Library-level functions for listing OCI referrers against
+              OCI Distribution-compliant registries.
+
+.. moduleauthor:: ToddySM <toddysm@gmail.com>
+
+Each function accepts a :class:`~regshape.libs.transport.RegistryClient`
+instance that is already initialised with the target registry, credentials,
+and transport settings.  The functions are intentionally free of Click/CLI
+concerns — error reporting is the caller's responsibility.
+"""
+
+import re
+from typing import Optional
+from urllib.parse import parse_qs, urlparse
+
+import requests
+
+from regshape.libs.decorators.scenario import track_scenario
+from regshape.libs.decorators.timing import track_time
+from regshape.libs.errors import AuthError, ReferrerError
+from regshape.libs.models.error import OciErrorResponse
+from regshape.libs.models.referrer import ReferrerList
+from regshape.libs.transport import RegistryClient
+
+
+# ===========================================================================
+# Public domain operations
+# ===========================================================================
+
+
+@track_time
+def list_referrers(
+    client: RegistryClient,
+    repo: str,
+    digest: str,
+    artifact_type: Optional[str] = None,
+) -> ReferrerList:
+    """Fetch the referrer list for the manifest identified by *digest*.
+
+    Issues a GET request to ``/v2/{repo}/referrers/{digest}``.  The
+    401→auth→retry cycle is handled transparently by *client*.
+
+    When *artifact_type* is provided, the ``artifactType`` query parameter
+    is sent to request server-side filtering.  If the registry does not
+    support server-side filtering (no ``OCI-Filters-Applied`` response
+    header), client-side filtering is applied transparently.
+
+    :param client: Authenticated transport client for the target registry.
+    :param repo: Repository name (e.g. ``myrepo/myimage``).
+    :param digest: Manifest digest in ``algorithm:hex`` form
+        (e.g. ``sha256:abc123...``).
+    :param artifact_type: Optional artifact type to filter on.
+        ``None`` omits the parameter.
+    :returns: A :class:`~regshape.libs.models.referrer.ReferrerList` instance.
+    :raises AuthError: On authentication failure.
+    :raises ReferrerError: On a non-2xx registry response or parse failure.
+    :raises requests.exceptions.RequestException: On transport errors.
+    """
+    path = f"/v2/{repo}/referrers/{digest}"
+    params: dict = {}
+    if artifact_type is not None:
+        params["artifactType"] = artifact_type
+
+    response = client.get(path, params=params if params else None)
+    _raise_for_list_error(response, client.config.registry, repo, digest)
+
+    try:
+        result = ReferrerList.from_json(response.text)
+    except ReferrerError:
+        raise
+    except Exception as exc:
+        raise ReferrerError(
+            f"Failed to parse referrers response from "
+            f"{client.config.registry}/{repo}@{digest}",
+            str(exc),
+        ) from exc
+
+    # Client-side filtering when the registry did not apply server-side
+    # filtering.
+    if artifact_type is not None:
+        filters_applied = response.headers.get("OCI-Filters-Applied", "")
+        if "artifactType" not in filters_applied:
+            result = result.filter_by_artifact_type(artifact_type)
+
+    return result
+
+
+@track_scenario("referrer list all")
+def list_referrers_all(
+    client: RegistryClient,
+    repo: str,
+    digest: str,
+    artifact_type: Optional[str] = None,
+) -> ReferrerList:
+    """Fetch all pages of the referrer list and return them merged.
+
+    Follows ``Link: rel="next"`` response headers until all pages have been
+    retrieved, then returns a single
+    :class:`~regshape.libs.models.referrer.ReferrerList` whose ``manifests``
+    list is the ordered concatenation of every page.
+
+    Client-side ``artifactType`` filtering is applied once on the final
+    merged result, not per-page.
+
+    :param client: Authenticated transport client for the target registry.
+    :param repo: Repository name (e.g. ``myrepo/myimage``).
+    :param digest: Manifest digest in ``algorithm:hex`` form.
+    :param artifact_type: Optional artifact type to filter on.
+    :returns: A single :class:`~regshape.libs.models.referrer.ReferrerList`
+        containing all referrers.
+    :raises AuthError: On authentication failure.
+    :raises ReferrerError: On a non-2xx registry response or parse failure.
+    :raises requests.exceptions.RequestException: On transport errors.
+    """
+    # Fetch the first page via list_referrers (carries @track_time).
+    page = list_referrers(client, repo, digest, artifact_type)
+    accumulated = ReferrerList(manifests=list(page.manifests))
+
+    # Follow Link headers for subsequent pages.
+    while True:
+        next_url = _parse_next_url(dict(client.last_response.headers))
+        if next_url is None:
+            break
+
+        response = client.get(next_url)
+        _raise_for_list_error(response, client.config.registry, repo, digest)
+
+        try:
+            page = ReferrerList.from_json(response.text)
+        except ReferrerError:
+            raise
+        except Exception as exc:
+            raise ReferrerError(
+                f"Failed to parse referrers response from "
+                f"{client.config.registry}/{repo}@{digest}",
+                str(exc),
+            ) from exc
+
+        accumulated = accumulated.merge(page)
+
+    return accumulated
+
+
+# ===========================================================================
+# Private error helpers
+# ===========================================================================
+
+
+def _raise_for_list_error(
+    response: requests.Response,
+    registry: str,
+    repo: str,
+    digest: str,
+) -> None:
+    """Raise on non-2xx responses for a referrers operation.
+
+    * 401 → :class:`~regshape.libs.errors.AuthError`
+    * 404 → :class:`~regshape.libs.errors.ReferrerError` "Manifest not found"
+    * other → :class:`~regshape.libs.errors.ReferrerError` generic
+
+    :raises AuthError: On 401.
+    :raises ReferrerError: On all other non-2xx status codes.
+    """
+    if 200 <= response.status_code < 300:
+        return
+
+    detail = (
+        OciErrorResponse.from_response(response).first_detail() or response.text[:200]
+    )
+
+    if response.status_code == 401:
+        raise AuthError(
+            f"Authentication failed for {registry}",
+            detail or "HTTP 401",
+        )
+    if response.status_code == 404:
+        raise ReferrerError(
+            f"Manifest not found: {registry}/{repo}@{digest}",
+            detail or "HTTP 404",
+        )
+    raise ReferrerError(
+        f"Registry error for {registry}/{repo}@{digest}",
+        detail or f"HTTP {response.status_code}",
+    )
+
+
+def _parse_next_url(headers: dict) -> Optional[str]:
+    """Parse the OCI ``Link`` response header and return the next-page URL.
+
+    The OCI pagination ``Link`` header format is::
+
+        Link: </v2/<name>/referrers/<digest>?...>; rel="next"
+
+    Extracts the URL inside ``<...>`` and checks for ``rel="next"``.
+
+    :param headers: Response headers dict.
+    :returns: The relative URL string for the next page, or ``None`` if
+        there is no next page.
+    """
+    link_header = headers.get("Link") or headers.get("link") or ""
+    if not link_header:
+        return None
+
+    for segment in link_header.split(","):
+        segment = segment.strip()
+        url_match = re.search(r"<([^>]+)>", segment)
+        if not url_match:
+            continue
+        if not re.search(r'rel=["\']?next["\']?', segment):
+            continue
+        return url_match.group(1)
+
+    return None

--- a/src/regshape/libs/transport/client.py
+++ b/src/regshape/libs/transport/client.py
@@ -240,11 +240,18 @@ class RegistryClient:
         # -- 401 handling --------------------------------------------------------
         www_auth = response.headers.get("WWW-Authenticate", "")
         if not www_auth:
-            raise AuthError(
-                "Authentication failed",
-                f"registry {self.config.registry!r} returned 401 without "
-                "a WWW-Authenticate header",
-            )
+            # Some registries (e.g. ACR) only return WWW-Authenticate on
+            # the /v2/ endpoint.  Fall back to a /v2/ probe.
+            v2_url = f"{self.base_url}/v2/"
+            v2_resp = http_request(v2_url, "GET", headers={}, timeout=timeout)
+            if v2_resp.status_code == 401:
+                www_auth = v2_resp.headers.get("WWW-Authenticate", "")
+            if not www_auth:
+                raise AuthError(
+                    "Authentication failed",
+                    f"registry {self.config.registry!r} returned 401 without "
+                    "a WWW-Authenticate header",
+                )
 
         auth_scheme = www_auth.split(" ", 1)[0]
         if auth_scheme.lower() == "basic" and (

--- a/src/regshape/libs/transport/middleware.py
+++ b/src/regshape/libs/transport/middleware.py
@@ -255,6 +255,26 @@ import requests.exceptions
 # Internal helpers
 # ---------------------------------------------------------------------------
 
+def _get_header_ci(headers: dict, name: str, default: str = "") -> str:
+    """Case-insensitive header lookup.
+
+    ``RegistryResponse.headers`` is a plain ``dict`` whose keys preserve
+    the original casing from the server (e.g. ``Www-Authenticate`` from
+    Azure Container Registry).  This helper performs a case-insensitive
+    search so that header checks work regardless of server casing.
+    """
+    # Fast path — exact match
+    value = headers.get(name)
+    if value is not None:
+        return value
+    # Slow path — case-insensitive scan
+    lower_name = name.lower()
+    for key, value in headers.items():
+        if key.lower() == lower_name:
+            return value
+    return default
+
+
 def _normalize_www_authenticate(www_auth: str) -> tuple[str, str]:
     """Normalize a WWW-Authenticate header value.
 
@@ -359,13 +379,18 @@ class AuthMiddleware(BaseMiddleware):
             return response
 
         # ---- 401 handling ------------------------------------------------
-        www_auth = response.headers.get("WWW-Authenticate", "")
+        www_auth = _get_header_ci(response.headers, "WWW-Authenticate")
         if not www_auth:
-            raise AuthError(
-                "Authentication failed",
-                f"registry {self._registry!r} returned 401 without "
-                "a WWW-Authenticate header",
-            )
+            # Some registries (e.g. ACR) only return WWW-Authenticate on
+            # the /v2/ endpoint.  Fall back to a /v2/ probe to obtain the
+            # challenge, then retry the original request.
+            www_auth = self._probe_v2_challenge(next_handler, processed_request)
+            if not www_auth:
+                raise AuthError(
+                    "Authentication failed",
+                    f"registry {self._registry!r} returned 401 without "
+                    "a WWW-Authenticate header",
+                )
 
         auth_scheme = www_auth.split(" ", 1)[0]
         if auth_scheme.lower() == "basic" and (
@@ -399,6 +424,34 @@ class AuthMiddleware(BaseMiddleware):
         )
 
         return next_handler(retry_request)
+
+    # -- Private helpers ---------------------------------------------------
+
+    @staticmethod
+    def _probe_v2_challenge(
+        next_handler: Callable[[RegistryRequest], RegistryResponse],
+        original_request: RegistryRequest,
+    ) -> str:
+        """Issue ``GET /v2/`` to obtain a ``WWW-Authenticate`` challenge.
+
+        Some registries only return the challenge header on the ``/v2/``
+        base endpoint rather than on every 401 response.  This helper
+        sends a lightweight probe so that the caller can still negotiate
+        authentication.
+
+        :returns: The ``WWW-Authenticate`` header value, or an empty
+            string if the probe also lacks one.
+        """
+        probe = RegistryRequest(
+            method="GET",
+            url="/v2/",
+            headers={},
+            timeout=original_request.timeout,
+        )
+        probe_response = next_handler(probe)
+        if probe_response.status_code == 401:
+            return _get_header_ci(probe_response.headers, "WWW-Authenticate")
+        return ""
 
 
 class LoggingMiddleware(BaseMiddleware):

--- a/src/regshape/tests/test_client_middleware_integration.py
+++ b/src/regshape/tests/test_client_middleware_integration.py
@@ -414,3 +414,352 @@ class TestRegistryClientMiddlewareErrorHandling:
         
         with pytest.raises(RuntimeError, match="Middleware failure"):
             client.post("/v2/test/blobs/uploads/")
+
+
+class TestAuthV2Fallback:
+    """Test the /v2/ fallback when 401 lacks WWW-Authenticate.
+
+    Some registries (e.g. Azure Container Registry) only return the
+    WWW-Authenticate challenge header on the ``/v2/`` base endpoint, not
+    on resource-specific endpoints like ``/v2/<name>/tags/list``.  Both
+    the middleware path and the legacy path must fall back to probing
+    ``/v2/`` to obtain the challenge in this case.
+    """
+
+    # -- Middleware path ----------------------------------------------------
+
+    @patch('regshape.libs.transport.client.resolve_credentials')
+    @patch('regshape.libs.transport.client.http_request')
+    def test_middleware_v2_fallback_authenticates_successfully(
+        self, mock_http_request, mock_resolve,
+    ):
+        """Middleware: 401 without WWW-Authenticate falls back to /v2/ probe."""
+        mock_resolve.return_value = ("user", "pass")
+
+        # 1st call: original request → 401 *without* WWW-Authenticate
+        no_challenge = Mock(spec=requests.Response)
+        no_challenge.status_code = 401
+        no_challenge.headers = {}
+        no_challenge.content = b"Unauthorized"
+        no_challenge.text = "Unauthorized"
+
+        # 2nd call: /v2/ probe → 401 *with* WWW-Authenticate
+        v2_challenge = Mock(spec=requests.Response)
+        v2_challenge.status_code = 401
+        v2_challenge.headers = {
+            "WWW-Authenticate": 'Bearer realm="https://auth.example.com/token",service="registry"',
+        }
+        v2_challenge.content = b"Unauthorized"
+        v2_challenge.text = "Unauthorized"
+
+        # 3rd call: retried original request with Authorization → 200
+        success = Mock(spec=requests.Response)
+        success.status_code = 200
+        success.headers = {"Content-Type": "application/json"}
+        success.content = b'{"tags":["v1"]}'
+        success.text = '{"tags":["v1"]}'
+
+        mock_http_request.side_effect = [no_challenge, v2_challenge, success]
+
+        config = TransportConfig("registry.example.com")
+        client = RegistryClient(config)
+
+        with patch(
+            "regshape.libs.transport.middleware.registryauth.authenticate"
+        ) as mock_auth:
+            mock_auth.return_value = "a-bearer-token"
+            response = client.get("/v2/test/tags/list")
+
+        assert response.status_code == 200
+        assert mock_http_request.call_count == 3
+
+        # 1st: original request (no auth header)
+        first_headers = mock_http_request.call_args_list[0][1]["headers"]
+        assert "Authorization" not in first_headers
+
+        # 2nd: /v2/ probe (no auth header)
+        second_url = mock_http_request.call_args_list[1][1]["url"]
+        assert second_url.endswith("/v2/")
+
+        # 3rd: retried original request with auth
+        third_headers = mock_http_request.call_args_list[2][1]["headers"]
+        assert third_headers["Authorization"] == "Bearer a-bearer-token"
+        third_url = mock_http_request.call_args_list[2][1]["url"]
+        assert "/v2/test/tags/list" in third_url
+
+    @patch('regshape.libs.transport.client.resolve_credentials')
+    @patch('regshape.libs.transport.client.http_request')
+    def test_middleware_v2_fallback_probe_also_missing_challenge(
+        self, mock_http_request, mock_resolve,
+    ):
+        """Middleware: raise AuthError when /v2/ probe also lacks WWW-Authenticate."""
+        mock_resolve.return_value = ("user", "pass")
+
+        # 1st call: original → 401 without WWW-Authenticate
+        no_challenge = Mock(spec=requests.Response)
+        no_challenge.status_code = 401
+        no_challenge.headers = {}
+        no_challenge.content = b"Unauthorized"
+        no_challenge.text = "Unauthorized"
+
+        # 2nd call: /v2/ probe → also 401 without WWW-Authenticate
+        v2_no_challenge = Mock(spec=requests.Response)
+        v2_no_challenge.status_code = 401
+        v2_no_challenge.headers = {}
+        v2_no_challenge.content = b"Unauthorized"
+        v2_no_challenge.text = "Unauthorized"
+
+        mock_http_request.side_effect = [no_challenge, v2_no_challenge]
+
+        config = TransportConfig("registry.example.com")
+        client = RegistryClient(config)
+
+        with pytest.raises(AuthError, match="returned 401 without a WWW-Authenticate header"):
+            client.get("/v2/test/tags/list")
+
+    @patch('regshape.libs.transport.client.resolve_credentials')
+    @patch('regshape.libs.transport.client.http_request')
+    def test_middleware_v2_fallback_probe_returns_200(
+        self, mock_http_request, mock_resolve,
+    ):
+        """Middleware: raise AuthError when /v2/ probe returns 200 (no challenge)."""
+        mock_resolve.return_value = ("user", "pass")
+
+        no_challenge = Mock(spec=requests.Response)
+        no_challenge.status_code = 401
+        no_challenge.headers = {}
+        no_challenge.content = b"Unauthorized"
+        no_challenge.text = "Unauthorized"
+
+        # /v2/ probe succeeds without auth — no challenge to extract
+        v2_ok = Mock(spec=requests.Response)
+        v2_ok.status_code = 200
+        v2_ok.headers = {}
+        v2_ok.content = b"{}"
+        v2_ok.text = "{}"
+
+        mock_http_request.side_effect = [no_challenge, v2_ok]
+
+        config = TransportConfig("registry.example.com")
+        client = RegistryClient(config)
+
+        with pytest.raises(AuthError, match="returned 401 without a WWW-Authenticate header"):
+            client.get("/v2/test/tags/list")
+
+    @patch('regshape.libs.transport.client.resolve_credentials')
+    @patch('regshape.libs.transport.client.http_request')
+    def test_middleware_no_fallback_when_challenge_present(
+        self, mock_http_request, mock_resolve,
+    ):
+        """Middleware: normal 401 with WWW-Authenticate does not probe /v2/."""
+        mock_resolve.return_value = ("user", "pass")
+
+        challenge_401 = Mock(spec=requests.Response)
+        challenge_401.status_code = 401
+        challenge_401.headers = {
+            "WWW-Authenticate": 'Bearer realm="https://auth.example.com/token",service="reg"',
+        }
+        challenge_401.content = b"Unauthorized"
+        challenge_401.text = "Unauthorized"
+
+        success = Mock(spec=requests.Response)
+        success.status_code = 200
+        success.headers = {}
+        success.content = b"ok"
+        success.text = "ok"
+
+        mock_http_request.side_effect = [challenge_401, success]
+
+        config = TransportConfig("registry.example.com")
+        client = RegistryClient(config)
+
+        with patch(
+            "regshape.libs.transport.middleware.registryauth.authenticate"
+        ) as mock_auth:
+            mock_auth.return_value = "token"
+            response = client.get("/v2/test/tags/list")
+
+        assert response.status_code == 200
+        # Only 2 calls: the original + the retry — no /v2/ probe
+        assert mock_http_request.call_count == 2
+
+    # -- Legacy path --------------------------------------------------------
+
+    @patch('regshape.libs.transport.client.resolve_credentials')
+    @patch('regshape.libs.transport.client.http_request')
+    def test_legacy_v2_fallback_authenticates_successfully(
+        self, mock_http_request, mock_resolve,
+    ):
+        """Legacy: 401 without WWW-Authenticate falls back to /v2/ probe."""
+        mock_resolve.return_value = ("user", "pass")
+
+        no_challenge = _create_mock_response(401, {}, b"Unauthorized")
+
+        v2_challenge = _create_mock_response(
+            401,
+            {"WWW-Authenticate": 'Bearer realm="https://auth.example.com/token",service="reg"'},
+            b"Unauthorized",
+        )
+
+        success = _create_mock_response(200, {}, b'{"tags":["v1"]}')
+
+        mock_http_request.side_effect = [no_challenge, v2_challenge, success]
+
+        config = TransportConfig("registry.example.com", enable_middleware=False)
+        client = RegistryClient(config)
+
+        with patch(
+            "regshape.libs.auth.registryauth.authenticate"
+        ) as mock_auth, patch(
+            "regshape.libs.transport.client._normalize_www_authenticate"
+        ) as mock_normalize:
+            mock_normalize.return_value = (
+                'Bearer realm="https://auth.example.com/token",service="reg"',
+                "Bearer",
+            )
+            mock_auth.return_value = "a-bearer-token"
+            response = client.get("/v2/test/tags/list")
+
+        assert response.status_code == 200
+        assert mock_http_request.call_count == 3
+
+        # The /v2/ probe should target the base URL
+        v2_url = mock_http_request.call_args_list[1][0][0]
+        assert v2_url.endswith("/v2/")
+
+    @patch('regshape.libs.transport.client.resolve_credentials')
+    @patch('regshape.libs.transport.client.http_request')
+    def test_legacy_v2_fallback_probe_also_missing_challenge(
+        self, mock_http_request, mock_resolve,
+    ):
+        """Legacy: raise AuthError when /v2/ probe also lacks WWW-Authenticate."""
+        mock_resolve.return_value = ("user", "pass")
+
+        no_challenge = _create_mock_response(401, {}, b"Unauthorized")
+        v2_no_challenge = _create_mock_response(401, {}, b"Unauthorized")
+
+        mock_http_request.side_effect = [no_challenge, v2_no_challenge]
+
+        config = TransportConfig("registry.example.com", enable_middleware=False)
+        client = RegistryClient(config)
+
+        with pytest.raises(AuthError, match="returned 401 without a WWW-Authenticate header"):
+            client.get("/v2/test/tags/list")
+
+    @patch('regshape.libs.transport.client.resolve_credentials')
+    @patch('regshape.libs.transport.client.http_request')
+    def test_legacy_no_fallback_when_challenge_present(
+        self, mock_http_request, mock_resolve,
+    ):
+        """Legacy: normal 401 with WWW-Authenticate does not probe /v2/."""
+        mock_resolve.return_value = ("user", "pass")
+
+        challenge = _create_mock_response(
+            401,
+            {"WWW-Authenticate": 'Basic realm="test"'},
+            b"Unauthorized",
+        )
+        success = _create_mock_response(200, {}, b"ok")
+
+        mock_http_request.side_effect = [challenge, success]
+
+        config = TransportConfig("registry.example.com", enable_middleware=False)
+        client = RegistryClient(config)
+
+        with patch(
+            "regshape.libs.auth.registryauth.authenticate"
+        ) as mock_auth, patch(
+            "regshape.libs.transport.client._normalize_www_authenticate"
+        ) as mock_normalize:
+            mock_normalize.return_value = ('Basic realm="test"', "Basic")
+            mock_auth.return_value = "base64creds"
+            response = client.get("/v2/test/tags/list")
+
+        assert response.status_code == 200
+        # Only 2 calls — no /v2/ probe
+        assert mock_http_request.call_count == 2
+
+    # -- Case-insensitive header matching -----------------------------------
+
+    @patch('regshape.libs.transport.client.resolve_credentials')
+    @patch('regshape.libs.transport.client.http_request')
+    def test_middleware_title_case_www_authenticate_header(
+        self, mock_http_request, mock_resolve,
+    ):
+        """Middleware: ACR-style 'Www-Authenticate' (title-case) is recognised."""
+        mock_resolve.return_value = ("user", "pass")
+
+        # ACR returns the header as "Www-Authenticate", not "WWW-Authenticate"
+        challenge_401 = Mock(spec=requests.Response)
+        challenge_401.status_code = 401
+        challenge_401.headers = {
+            "Www-Authenticate": 'Bearer realm="https://acr.example.com/oauth2/token",service="acr"',
+        }
+        challenge_401.content = b"Unauthorized"
+        challenge_401.text = "Unauthorized"
+
+        success = Mock(spec=requests.Response)
+        success.status_code = 200
+        success.headers = {}
+        success.content = b'{"tags":["v1"]}'
+        success.text = '{"tags":["v1"]}'
+
+        mock_http_request.side_effect = [challenge_401, success]
+
+        config = TransportConfig("registry.example.com")
+        client = RegistryClient(config)
+
+        with patch(
+            "regshape.libs.transport.middleware.registryauth.authenticate"
+        ) as mock_auth:
+            mock_auth.return_value = "a-bearer-token"
+            response = client.get("/v2/test/tags/list")
+
+        assert response.status_code == 200
+        # Only 2 calls — challenge found on first response, no /v2/ probe
+        assert mock_http_request.call_count == 2
+
+    @patch('regshape.libs.transport.client.resolve_credentials')
+    @patch('regshape.libs.transport.client.http_request')
+    def test_middleware_v2_fallback_with_title_case_header(
+        self, mock_http_request, mock_resolve,
+    ):
+        """Middleware: /v2/ fallback finds title-case 'Www-Authenticate'."""
+        mock_resolve.return_value = ("user", "pass")
+
+        # 1st: original → 401 with empty headers
+        no_challenge = Mock(spec=requests.Response)
+        no_challenge.status_code = 401
+        no_challenge.headers = {}
+        no_challenge.content = b"Unauthorized"
+        no_challenge.text = "Unauthorized"
+
+        # 2nd: /v2/ probe → 401 with ACR-style title-case header
+        v2_challenge = Mock(spec=requests.Response)
+        v2_challenge.status_code = 401
+        v2_challenge.headers = {
+            "Www-Authenticate": 'Bearer realm="https://acr.example.com/oauth2/token",service="acr"',
+        }
+        v2_challenge.content = b"Unauthorized"
+        v2_challenge.text = "Unauthorized"
+
+        # 3rd: retried original → 200
+        success = Mock(spec=requests.Response)
+        success.status_code = 200
+        success.headers = {}
+        success.content = b'{"tags":["v1"]}'
+        success.text = '{"tags":["v1"]}'
+
+        mock_http_request.side_effect = [no_challenge, v2_challenge, success]
+
+        config = TransportConfig("registry.example.com")
+        client = RegistryClient(config)
+
+        with patch(
+            "regshape.libs.transport.middleware.registryauth.authenticate"
+        ) as mock_auth:
+            mock_auth.return_value = "a-bearer-token"
+            response = client.get("/v2/test/tags/list")
+
+        assert response.status_code == 200
+        assert mock_http_request.call_count == 3

--- a/src/regshape/tests/test_referrer_cli.py
+++ b/src/regshape/tests/test_referrer_cli.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+"""Tests for :mod:`regshape.cli.referrer`."""
+
+import json
+
+import pytest
+import requests
+from click.testing import CliRunner
+from unittest.mock import MagicMock, patch
+
+from regshape.cli.main import regshape
+from regshape.libs.errors import AuthError, ReferrerError
+from regshape.libs.models.descriptor import Descriptor
+from regshape.libs.models.referrer import ReferrerList
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REGISTRY = "acr.example.io"
+REPO = "myrepo/myimage"
+DIGEST = "sha256:" + "a" * 64
+SBOM_TYPE = "application/vnd.example.sbom.v1"
+SIG_TYPE = "application/vnd.cncf.notary.signature"
+MANIFEST_MT = "application/vnd.oci.image.manifest.v1+json"
+IMAGE_REF = f"{REGISTRY}/{REPO}@{DIGEST}"
+TAG_REF = f"{REGISTRY}/{REPO}:v1.0"
+
+
+def _referrer_list(manifests: list[Descriptor] | None = None) -> ReferrerList:
+    return ReferrerList(manifests=manifests or [])
+
+
+def _descriptor(digest: str = DIGEST, artifact_type: str = SBOM_TYPE, size: int = 1234) -> Descriptor:
+    return Descriptor(
+        media_type=MANIFEST_MT,
+        digest=digest,
+        size=size,
+        artifact_type=artifact_type,
+    )
+
+
+def _runner():
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# TestReferrerListCommand
+# ---------------------------------------------------------------------------
+
+class TestReferrerListCommand:
+
+    def test_list_prints_one_referrer_per_line(self):
+        digest2 = "sha256:" + "b" * 64
+        rl = _referrer_list([_descriptor(), _descriptor(digest2, SIG_TYPE, 567)])
+        with patch("regshape.cli.referrer.list_referrers", return_value=rl):
+            result = _runner().invoke(regshape, [
+                "referrer", "list", "-i", IMAGE_REF,
+            ])
+        assert result.exit_code == 0
+        assert DIGEST in result.output
+        assert SBOM_TYPE in result.output
+        assert "1234" in result.output
+        assert digest2 in result.output
+
+    def test_list_json_flag(self):
+        rl = _referrer_list([_descriptor()])
+        with patch("regshape.cli.referrer.list_referrers", return_value=rl):
+            result = _runner().invoke(regshape, [
+                "referrer", "list", "-i", IMAGE_REF, "--json",
+            ])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["schemaVersion"] == 2
+        assert len(parsed["manifests"]) == 1
+
+    def test_list_empty_referrers(self):
+        rl = _referrer_list([])
+        with patch("regshape.cli.referrer.list_referrers", return_value=rl):
+            result = _runner().invoke(regshape, [
+                "referrer", "list", "-i", IMAGE_REF,
+            ])
+        assert result.exit_code == 0
+        assert result.output.strip() == ""
+
+    def test_tag_reference_rejected_with_exit_code_2(self):
+        result = _runner().invoke(regshape, [
+            "referrer", "list", "-i", TAG_REF,
+        ])
+        assert result.exit_code == 2
+        assert "digest reference" in result.output
+
+    def test_passes_artifact_type(self):
+        rl = _referrer_list([_descriptor()])
+        with patch("regshape.cli.referrer.list_referrers", return_value=rl) as mock_fn:
+            _runner().invoke(regshape, [
+                "referrer", "list", "-i", IMAGE_REF,
+                "--artifact-type", SBOM_TYPE,
+            ])
+        assert mock_fn.call_args[1]["artifact_type"] == SBOM_TYPE
+
+    def test_all_flag_calls_list_referrers_all(self):
+        rl = _referrer_list([_descriptor()])
+        with patch("regshape.cli.referrer.list_referrers_all", return_value=rl) as mock_fn:
+            result = _runner().invoke(regshape, [
+                "referrer", "list", "-i", IMAGE_REF, "--all",
+            ])
+        assert result.exit_code == 0
+        mock_fn.assert_called_once()
+
+    def test_without_all_flag_calls_list_referrers(self):
+        rl = _referrer_list([_descriptor()])
+        with patch("regshape.cli.referrer.list_referrers", return_value=rl) as mock_fn:
+            result = _runner().invoke(regshape, [
+                "referrer", "list", "-i", IMAGE_REF,
+            ])
+        assert result.exit_code == 0
+        mock_fn.assert_called_once()
+
+    def test_auth_error_exits_1(self):
+        with patch("regshape.cli.referrer.list_referrers", side_effect=AuthError("auth failed")):
+            result = _runner().invoke(regshape, [
+                "referrer", "list", "-i", IMAGE_REF,
+            ])
+        assert result.exit_code == 1
+        assert "Error" in result.output
+
+    def test_referrer_error_exits_1(self):
+        with patch("regshape.cli.referrer.list_referrers",
+                   side_effect=ReferrerError("not found", "404")):
+            result = _runner().invoke(regshape, [
+                "referrer", "list", "-i", IMAGE_REF,
+            ])
+        assert result.exit_code == 1
+
+    def test_missing_image_ref_exits_nonzero(self):
+        result = _runner().invoke(regshape, [
+            "referrer", "list",
+        ])
+        assert result.exit_code != 0
+
+    def test_output_flag_writes_to_file(self, tmp_path):
+        rl = _referrer_list([_descriptor()])
+        outfile = tmp_path / "out.txt"
+        with patch("regshape.cli.referrer.list_referrers", return_value=rl):
+            result = _runner().invoke(regshape, [
+                "referrer", "list", "-i", IMAGE_REF,
+                "--output", str(outfile),
+            ])
+        assert result.exit_code == 0
+        content = outfile.read_text()
+        assert DIGEST in content

--- a/src/regshape/tests/test_referrer_cli.py
+++ b/src/regshape/tests/test_referrer_cli.py
@@ -7,7 +7,7 @@ import json
 import pytest
 import requests
 from click.testing import CliRunner
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from regshape.cli.main import regshape
 from regshape.libs.errors import AuthError, ReferrerError
@@ -152,3 +152,12 @@ class TestReferrerListCommand:
         assert result.exit_code == 0
         content = outfile.read_text()
         assert DIGEST in content
+
+    def test_request_exception_exits_1(self):
+        with patch("regshape.cli.referrer.list_referrers",
+                   side_effect=requests.exceptions.ConnectionError("refused")):
+            result = _runner().invoke(regshape, [
+                "referrer", "list", "-i", IMAGE_REF,
+            ])
+        assert result.exit_code == 1
+        assert "Error" in result.output

--- a/src/regshape/tests/test_referrer_model.py
+++ b/src/regshape/tests/test_referrer_model.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+
+"""Tests for :mod:`regshape.libs.models.referrer`."""
+
+import json
+
+import pytest
+
+from regshape.libs.errors import ReferrerError
+from regshape.libs.models.descriptor import Descriptor
+from regshape.libs.models.referrer import ReferrerList
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DIGEST_1 = "sha256:" + "a" * 64
+DIGEST_2 = "sha256:" + "b" * 64
+SBOM_TYPE = "application/vnd.example.sbom.v1"
+SIG_TYPE = "application/vnd.cncf.notary.signature"
+MANIFEST_MT = "application/vnd.oci.image.manifest.v1+json"
+INDEX_MT = "application/vnd.oci.image.index.v1+json"
+
+
+def _descriptor_dict(digest: str = DIGEST_1, artifact_type: str = SBOM_TYPE, size: int = 1234) -> dict:
+    return {
+        "mediaType": MANIFEST_MT,
+        "digest": digest,
+        "size": size,
+        "artifactType": artifact_type,
+    }
+
+
+def _full_response(manifests: list[dict] | None = None) -> dict:
+    d: dict = {
+        "schemaVersion": 2,
+        "mediaType": INDEX_MT,
+    }
+    if manifests is not None:
+        d["manifests"] = manifests
+    return d
+
+
+# ---------------------------------------------------------------------------
+# ReferrerList.from_dict
+# ---------------------------------------------------------------------------
+
+class TestReferrerListFromDict:
+
+    def test_happy_path(self):
+        data = _full_response([_descriptor_dict(DIGEST_1), _descriptor_dict(DIGEST_2, SIG_TYPE)])
+        rl = ReferrerList.from_dict(data)
+        assert len(rl.manifests) == 2
+        assert rl.manifests[0].digest == DIGEST_1
+        assert rl.manifests[1].digest == DIGEST_2
+
+    def test_empty_manifests(self):
+        data = _full_response([])
+        rl = ReferrerList.from_dict(data)
+        assert rl.manifests == []
+
+    def test_null_manifests_normalised_to_empty_list(self):
+        data = _full_response()
+        data["manifests"] = None
+        rl = ReferrerList.from_dict(data)
+        assert rl.manifests == []
+
+    def test_missing_manifests_key_normalised_to_empty_list(self):
+        data = {"schemaVersion": 2, "mediaType": INDEX_MT}
+        rl = ReferrerList.from_dict(data)
+        assert rl.manifests == []
+
+    def test_non_dict_raises_referrer_error(self):
+        with pytest.raises(ReferrerError, match="expected a dict"):
+            ReferrerList.from_dict(["not", "a", "dict"])
+
+    def test_none_input_raises_referrer_error(self):
+        with pytest.raises(ReferrerError, match="expected a dict"):
+            ReferrerList.from_dict(None)
+
+    def test_non_list_manifests_raises_referrer_error(self):
+        data = _full_response()
+        data["manifests"] = "not-a-list"
+        with pytest.raises(ReferrerError, match="must be a list"):
+            ReferrerList.from_dict(data)
+
+    def test_invalid_descriptor_raises_referrer_error(self):
+        data = _full_response([{"bad": "descriptor"}])
+        with pytest.raises(ReferrerError, match="failed to parse descriptor"):
+            ReferrerList.from_dict(data)
+
+    def test_preserves_descriptor_order(self):
+        descs = [_descriptor_dict(DIGEST_2, SIG_TYPE, 100), _descriptor_dict(DIGEST_1, SBOM_TYPE, 200)]
+        data = _full_response(descs)
+        rl = ReferrerList.from_dict(data)
+        assert rl.manifests[0].digest == DIGEST_2
+        assert rl.manifests[1].digest == DIGEST_1
+
+    def test_annotations_preserved(self):
+        desc = _descriptor_dict()
+        desc["annotations"] = {"org.opencontainers.image.created": "2025-06-15T10:30:00Z"}
+        data = _full_response([desc])
+        rl = ReferrerList.from_dict(data)
+        assert rl.manifests[0].annotations == {"org.opencontainers.image.created": "2025-06-15T10:30:00Z"}
+
+
+# ---------------------------------------------------------------------------
+# ReferrerList.from_json
+# ---------------------------------------------------------------------------
+
+class TestReferrerListFromJson:
+
+    def test_happy_path(self):
+        payload = json.dumps(_full_response([_descriptor_dict()]))
+        rl = ReferrerList.from_json(payload)
+        assert len(rl.manifests) == 1
+        assert rl.manifests[0].digest == DIGEST_1
+
+    def test_malformed_json_raises_referrer_error(self):
+        with pytest.raises(ReferrerError, match="Failed to parse referrers JSON"):
+            ReferrerList.from_json("{not valid json}")
+
+    def test_empty_manifests_in_json(self):
+        payload = json.dumps(_full_response([]))
+        rl = ReferrerList.from_json(payload)
+        assert rl.manifests == []
+
+    def test_non_object_json_raises_referrer_error(self):
+        with pytest.raises(ReferrerError, match="expected a dict"):
+            ReferrerList.from_json('["list", "not", "object"]')
+
+
+# ---------------------------------------------------------------------------
+# ReferrerList.to_dict
+# ---------------------------------------------------------------------------
+
+class TestReferrerListToDict:
+
+    def test_emits_image_index_envelope(self):
+        rl = ReferrerList(manifests=[])
+        d = rl.to_dict()
+        assert d["schemaVersion"] == 2
+        assert d["mediaType"] == INDEX_MT
+        assert d["manifests"] == []
+
+    def test_round_trip(self):
+        desc = _descriptor_dict()
+        data = _full_response([desc])
+        rl = ReferrerList.from_dict(data)
+        d = rl.to_dict()
+        assert d["schemaVersion"] == 2
+        assert d["mediaType"] == INDEX_MT
+        assert len(d["manifests"]) == 1
+        assert d["manifests"][0]["digest"] == DIGEST_1
+
+    def test_empty_manifests_emitted(self):
+        rl = ReferrerList(manifests=[])
+        assert rl.to_dict()["manifests"] == []
+
+
+# ---------------------------------------------------------------------------
+# ReferrerList.to_json
+# ---------------------------------------------------------------------------
+
+class TestReferrerListToJson:
+
+    def test_produces_valid_json(self):
+        rl = ReferrerList.from_dict(_full_response([_descriptor_dict()]))
+        parsed = json.loads(rl.to_json())
+        assert parsed["schemaVersion"] == 2
+        assert len(parsed["manifests"]) == 1
+
+    def test_compact_separators(self):
+        rl = ReferrerList(manifests=[])
+        s = rl.to_json()
+        assert " " not in s
+
+    def test_sort_keys(self):
+        rl = ReferrerList(manifests=[])
+        s = rl.to_json()
+        assert s.index('"manifests"') < s.index('"mediaType"') < s.index('"schemaVersion"')
+
+    def test_round_trip_via_json(self):
+        rl = ReferrerList.from_dict(_full_response([_descriptor_dict()]))
+        rl2 = ReferrerList.from_json(rl.to_json())
+        assert len(rl2.manifests) == len(rl.manifests)
+        assert rl2.manifests[0].digest == rl.manifests[0].digest
+
+
+# ---------------------------------------------------------------------------
+# ReferrerList.filter_by_artifact_type
+# ---------------------------------------------------------------------------
+
+class TestFilterByArtifactType:
+
+    def test_filters_matching_type(self):
+        descs = [_descriptor_dict(DIGEST_1, SBOM_TYPE), _descriptor_dict(DIGEST_2, SIG_TYPE)]
+        rl = ReferrerList.from_dict(_full_response(descs))
+        filtered = rl.filter_by_artifact_type(SBOM_TYPE)
+        assert len(filtered.manifests) == 1
+        assert filtered.manifests[0].digest == DIGEST_1
+
+    def test_returns_empty_when_no_match(self):
+        descs = [_descriptor_dict(DIGEST_1, SBOM_TYPE)]
+        rl = ReferrerList.from_dict(_full_response(descs))
+        filtered = rl.filter_by_artifact_type("no/match")
+        assert filtered.manifests == []
+
+    def test_returns_all_when_all_match(self):
+        descs = [_descriptor_dict(DIGEST_1, SBOM_TYPE), _descriptor_dict(DIGEST_2, SBOM_TYPE)]
+        rl = ReferrerList.from_dict(_full_response(descs))
+        filtered = rl.filter_by_artifact_type(SBOM_TYPE)
+        assert len(filtered.manifests) == 2
+
+    def test_does_not_mutate_original(self):
+        descs = [_descriptor_dict(DIGEST_1, SBOM_TYPE), _descriptor_dict(DIGEST_2, SIG_TYPE)]
+        rl = ReferrerList.from_dict(_full_response(descs))
+        rl.filter_by_artifact_type(SBOM_TYPE)
+        assert len(rl.manifests) == 2
+
+
+# ---------------------------------------------------------------------------
+# ReferrerList.merge
+# ---------------------------------------------------------------------------
+
+class TestMerge:
+
+    def test_merges_two_lists(self):
+        rl1 = ReferrerList.from_dict(_full_response([_descriptor_dict(DIGEST_1)]))
+        rl2 = ReferrerList.from_dict(_full_response([_descriptor_dict(DIGEST_2)]))
+        merged = rl1.merge(rl2)
+        assert len(merged.manifests) == 2
+        assert merged.manifests[0].digest == DIGEST_1
+        assert merged.manifests[1].digest == DIGEST_2
+
+    def test_merge_with_empty(self):
+        rl1 = ReferrerList.from_dict(_full_response([_descriptor_dict(DIGEST_1)]))
+        rl2 = ReferrerList(manifests=[])
+        merged = rl1.merge(rl2)
+        assert len(merged.manifests) == 1
+
+    def test_merge_empty_with_nonempty(self):
+        rl1 = ReferrerList(manifests=[])
+        rl2 = ReferrerList.from_dict(_full_response([_descriptor_dict(DIGEST_1)]))
+        merged = rl1.merge(rl2)
+        assert len(merged.manifests) == 1
+
+    def test_does_not_mutate_originals(self):
+        rl1 = ReferrerList.from_dict(_full_response([_descriptor_dict(DIGEST_1)]))
+        rl2 = ReferrerList.from_dict(_full_response([_descriptor_dict(DIGEST_2)]))
+        rl1.merge(rl2)
+        assert len(rl1.manifests) == 1
+        assert len(rl2.manifests) == 1
+
+
+# ---------------------------------------------------------------------------
+# __post_init__ validation
+# ---------------------------------------------------------------------------
+
+class TestPostInit:
+
+    def test_rejects_non_list_manifests(self):
+        with pytest.raises(ValueError, match="manifests must be a list"):
+            ReferrerList(manifests="not-a-list")  # type: ignore[arg-type]

--- a/src/regshape/tests/test_referrer_operations.py
+++ b/src/regshape/tests/test_referrer_operations.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+
+"""Tests for :mod:`regshape.libs.referrers.operations`."""
+
+import json
+
+import pytest
+import requests
+from unittest.mock import MagicMock, PropertyMock
+
+from regshape.libs.errors import AuthError, ReferrerError
+from regshape.libs.referrers.operations import (
+    _parse_next_url,
+    _raise_for_list_error,
+    list_referrers,
+    list_referrers_all,
+)
+from regshape.libs.transport import RegistryClient, TransportConfig
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REGISTRY = "acr.example.io"
+REPO = "myrepo/myimage"
+DIGEST = "sha256:" + "a" * 64
+SBOM_TYPE = "application/vnd.example.sbom.v1"
+SIG_TYPE = "application/vnd.cncf.notary.signature"
+MANIFEST_MT = "application/vnd.oci.image.manifest.v1+json"
+INDEX_MT = "application/vnd.oci.image.index.v1+json"
+
+
+def _descriptor_dict(digest: str = DIGEST, artifact_type: str = SBOM_TYPE, size: int = 1234) -> dict:
+    return {
+        "mediaType": MANIFEST_MT,
+        "digest": digest,
+        "size": size,
+        "artifactType": artifact_type,
+    }
+
+
+def _referrer_response_json(manifests: list[dict] | None = None) -> str:
+    return json.dumps({
+        "schemaVersion": 2,
+        "mediaType": INDEX_MT,
+        "manifests": manifests if manifests is not None else [],
+    })
+
+
+def _mock_client() -> MagicMock:
+    client = MagicMock(spec=RegistryClient)
+    config = MagicMock(spec=TransportConfig)
+    config.registry = REGISTRY
+    client.config = config
+    return client
+
+
+def _make_response(
+    status_code: int,
+    body: str = "{}",
+    headers: dict | None = None,
+) -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.text = body
+    resp.headers = headers or {}
+    return resp
+
+
+# ===========================================================================
+# list_referrers
+# ===========================================================================
+
+class TestListReferrers:
+
+    def test_returns_referrer_list(self):
+        body = _referrer_response_json([_descriptor_dict()])
+        client = _mock_client()
+        client.get.return_value = _make_response(200, body=body)
+        result = list_referrers(client, REPO, DIGEST)
+        assert len(result.manifests) == 1
+        assert result.manifests[0].digest == DIGEST
+
+    def test_get_called_with_correct_path(self):
+        client = _mock_client()
+        client.get.return_value = _make_response(200, body=_referrer_response_json())
+        list_referrers(client, REPO, DIGEST)
+        client.get.assert_called_once()
+        assert client.get.call_args[0][0] == f"/v2/{REPO}/referrers/{DIGEST}"
+
+    def test_no_params_by_default(self):
+        client = _mock_client()
+        client.get.return_value = _make_response(200, body=_referrer_response_json())
+        list_referrers(client, REPO, DIGEST)
+        call_kwargs = client.get.call_args[1]
+        assert call_kwargs.get("params") is None
+
+    def test_artifact_type_forwarded_as_param(self):
+        client = _mock_client()
+        client.get.return_value = _make_response(200, body=_referrer_response_json())
+        list_referrers(client, REPO, DIGEST, artifact_type=SBOM_TYPE)
+        params = client.get.call_args[1].get("params")
+        assert params == {"artifactType": SBOM_TYPE}
+
+    def test_server_side_filtering_trusted(self):
+        """When OCI-Filters-Applied contains artifactType, trust the result."""
+        body = _referrer_response_json([_descriptor_dict(artifact_type=SBOM_TYPE)])
+        resp = _make_response(200, body=body, headers={"OCI-Filters-Applied": "artifactType"})
+        client = _mock_client()
+        client.get.return_value = resp
+        result = list_referrers(client, REPO, DIGEST, artifact_type=SBOM_TYPE)
+        assert len(result.manifests) == 1
+
+    def test_client_side_filtering_when_no_header(self):
+        """When OCI-Filters-Applied is absent, apply client-side filtering."""
+        descs = [_descriptor_dict(artifact_type=SBOM_TYPE), _descriptor_dict(artifact_type=SIG_TYPE)]
+        body = _referrer_response_json(descs)
+        resp = _make_response(200, body=body)
+        client = _mock_client()
+        client.get.return_value = resp
+        result = list_referrers(client, REPO, DIGEST, artifact_type=SBOM_TYPE)
+        assert len(result.manifests) == 1
+        assert result.manifests[0].artifact_type == SBOM_TYPE
+
+    def test_no_client_side_filtering_without_artifact_type(self):
+        """Without artifact_type, no filtering is applied."""
+        descs = [_descriptor_dict(artifact_type=SBOM_TYPE), _descriptor_dict(artifact_type=SIG_TYPE)]
+        body = _referrer_response_json(descs)
+        client = _mock_client()
+        client.get.return_value = _make_response(200, body=body)
+        result = list_referrers(client, REPO, DIGEST)
+        assert len(result.manifests) == 2
+
+    def test_404_raises_referrer_error(self):
+        client = _mock_client()
+        client.get.return_value = _make_response(404)
+        with pytest.raises(ReferrerError, match="Manifest not found"):
+            list_referrers(client, REPO, DIGEST)
+
+    def test_401_raises_auth_error(self):
+        client = _mock_client()
+        client.get.return_value = _make_response(401)
+        with pytest.raises(AuthError):
+            list_referrers(client, REPO, DIGEST)
+
+    def test_500_raises_referrer_error(self):
+        client = _mock_client()
+        client.get.return_value = _make_response(500)
+        with pytest.raises(ReferrerError):
+            list_referrers(client, REPO, DIGEST)
+
+    def test_invalid_json_raises_referrer_error(self):
+        client = _mock_client()
+        client.get.return_value = _make_response(200, body="not json")
+        with pytest.raises(ReferrerError, match="Failed to parse"):
+            list_referrers(client, REPO, DIGEST)
+
+
+# ===========================================================================
+# list_referrers_all
+# ===========================================================================
+
+DIGEST_PAGE2 = "sha256:" + "c" * 64
+
+
+class TestListReferrersAll:
+
+    def test_single_page_no_link(self):
+        body = _referrer_response_json([_descriptor_dict()])
+        resp = _make_response(200, body=body)
+        client = _mock_client()
+        client.get.return_value = resp
+        # last_response is used by list_referrers_all to check Link header
+        type(client).last_response = PropertyMock(return_value=resp)
+        result = list_referrers_all(client, REPO, DIGEST)
+        assert len(result.manifests) == 1
+
+    def test_follows_link_header_for_second_page(self):
+        page1_body = _referrer_response_json([_descriptor_dict(DIGEST)])
+        page2_body = _referrer_response_json([_descriptor_dict(DIGEST_PAGE2)])
+
+        resp1 = _make_response(200, body=page1_body,
+                               headers={"Link": '</v2/repo/referrers/d?last=x>; rel="next"'})
+        resp2 = _make_response(200, body=page2_body)
+
+        client = _mock_client()
+        client.get.side_effect = [resp1, resp2]
+        type(client).last_response = PropertyMock(side_effect=[resp1, resp2])
+
+        result = list_referrers_all(client, REPO, DIGEST)
+        assert len(result.manifests) == 2
+        assert result.manifests[0].digest == DIGEST
+        assert result.manifests[1].digest == DIGEST_PAGE2
+
+    def test_stops_when_no_link_header(self):
+        body = _referrer_response_json([_descriptor_dict()])
+        resp = _make_response(200, body=body)
+        client = _mock_client()
+        client.get.return_value = resp
+        type(client).last_response = PropertyMock(return_value=resp)
+        list_referrers_all(client, REPO, DIGEST)
+        # Only the first page should be fetched
+        assert client.get.call_count == 1
+
+
+# ===========================================================================
+# _raise_for_list_error — direct tests
+# ===========================================================================
+
+class TestRaiseForListError:
+
+    def test_2xx_is_silent(self):
+        for code in (200, 201, 202):
+            _raise_for_list_error(_make_response(code), REGISTRY, REPO, DIGEST)
+
+    def test_404_raises_referrer_error_with_digest_in_message(self):
+        with pytest.raises(ReferrerError, match=DIGEST):
+            _raise_for_list_error(_make_response(404), REGISTRY, REPO, DIGEST)
+
+    def test_401_raises_auth_error_with_registry_in_message(self):
+        with pytest.raises(AuthError, match=REGISTRY):
+            _raise_for_list_error(_make_response(401), REGISTRY, REPO, DIGEST)
+
+    def test_oci_error_detail_used_when_present(self):
+        body = json.dumps({"errors": [{"code": "MANIFEST_UNKNOWN", "message": "manifest not found"}]})
+        resp = _make_response(404, body=body)
+        with pytest.raises(ReferrerError, match="manifest not found"):
+            _raise_for_list_error(resp, REGISTRY, REPO, DIGEST)
+
+    def test_503_raises_referrer_error(self):
+        with pytest.raises(ReferrerError, match="Registry error"):
+            _raise_for_list_error(_make_response(503), REGISTRY, REPO, DIGEST)
+
+
+# ===========================================================================
+# _parse_next_url
+# ===========================================================================
+
+class TestParseNextUrl:
+
+    def test_extracts_url_from_link_header(self):
+        headers = {"Link": '</v2/repo/referrers/sha?last=abc&n=10>; rel="next"'}
+        assert _parse_next_url(headers) == "/v2/repo/referrers/sha?last=abc&n=10"
+
+    def test_returns_none_when_no_link(self):
+        assert _parse_next_url({}) is None
+
+    def test_returns_none_when_no_next_rel(self):
+        headers = {"Link": '</v2/repo/stuff>; rel="prev"'}
+        assert _parse_next_url(headers) is None
+
+    def test_handles_lowercase_link(self):
+        headers = {"link": '</v2/repo/referrers/sha?last=abc>; rel="next"'}
+        assert _parse_next_url(headers) == "/v2/repo/referrers/sha?last=abc"
+
+    def test_handles_multiple_relations(self):
+        headers = {"Link": '</prev>; rel="prev", </next?last=x>; rel="next"'}
+        assert _parse_next_url(headers) == "/next?last=x"
+
+    def test_empty_link_header(self):
+        assert _parse_next_url({"Link": ""}) is None

--- a/src/regshape/tests/test_referrer_operations.py
+++ b/src/regshape/tests/test_referrer_operations.py
@@ -203,6 +203,36 @@ class TestListReferrersAll:
         # Only the first page should be fetched
         assert client.get.call_count == 1
 
+    def test_client_side_filtering_applied_to_subsequent_pages(self):
+        """When the server does NOT set OCI-Filters-Applied, pages 2+
+        fetched via bare GET must still be client-side filtered."""
+        # Page 1: mixed types, no OCI-Filters-Applied header.
+        page1_body = _referrer_response_json([
+            _descriptor_dict(DIGEST, artifact_type=SBOM_TYPE),
+            _descriptor_dict(DIGEST, artifact_type=SIG_TYPE),
+        ])
+        resp1 = _make_response(
+            200, body=page1_body,
+            headers={"Link": '</v2/repo/referrers/d?last=x>; rel="next"'},
+        )
+
+        # Page 2: also mixed types, no OCI-Filters-Applied.
+        page2_body = _referrer_response_json([
+            _descriptor_dict(DIGEST_PAGE2, artifact_type=SBOM_TYPE),
+            _descriptor_dict(DIGEST_PAGE2, artifact_type=SIG_TYPE),
+        ])
+        resp2 = _make_response(200, body=page2_body)
+
+        client = _mock_client()
+        client.get.side_effect = [resp1, resp2]
+        type(client).last_response = PropertyMock(side_effect=[resp1, resp2])
+
+        result = list_referrers_all(client, REPO, DIGEST, artifact_type=SBOM_TYPE)
+
+        # Only SBOM_TYPE entries should remain from both pages.
+        assert len(result.manifests) == 2
+        assert all(m.artifact_type == SBOM_TYPE for m in result.manifests)
+
 
 # ===========================================================================
 # _raise_for_list_error — direct tests


### PR DESCRIPTION
## Summary

Implements the OCI Referrers API (`GET /v2/<name>/referrers/<digest>`) as described in the [OCI Distribution Spec v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers), and fixes an authentication bug that prevented regshape from working with Azure Container Registry (ACR).

Closes #31

---

## Changes

### 1. Design Specs (commit 46c2084)

Three design specification documents following project conventions:

- **`specs/operations/referrers.md`** — Operations layer spec: `list_referrers()` and `list_referrers_all()` with pagination via `Link` header
- **`specs/models/referrer.md`** — `ReferrerList` data model spec with `filter_by_artifact_type()` and `merge()` methods
- **`specs/cli/referrer.md`** — CLI command spec for `regshape referrer list` with all options

### 2. Referrers Implementation (commit 8a5666d)

**Model** — `ReferrerList` dataclass (`src/regshape/libs/models/referrer.py`):
- `from_dict()` / `from_json()` / `to_dict()` / `to_json()` serialization
- `filter_by_artifact_type(artifact_type)` for client-side filtering
- `merge(other)` for combining paginated results
- `to_dict()` emits a full OCI Image Index envelope (`schemaVersion: 2`, `mediaType: application/vnd.oci.image.index.v1+json`)

**Operations** — `src/regshape/libs/referrers/operations.py`:
- `list_referrers()` with `@track_time` — single-page fetch; checks `OCI-Filters-Applied` header and falls back to client-side filtering when absent
- `list_referrers_all()` with `@track_scenario("referrer list all")` — follows `Link: rel="next"` pagination headers
- `_raise_for_list_error()` — maps 401->AuthError, 404/other->ReferrerError
- `_parse_next_url()` — extracts the next page URL from the `Link` header

**CLI** — `src/regshape/cli/referrer.py`:
- `regshape referrer list` command with options:
  - `--image-ref / -i` (required, must contain digest)
  - `--artifact-type / -t` (optional filter)
  - `--all` (follow pagination)
  - `--json` (full Image Index output)
  - `--output / -o` (write to file)
- Rejects tag-only references with exit code 2
- Plain-text output: `<digest>  <artifactType>  <size>` per line

**Error handling** — `ReferrerError` added to `src/regshape/libs/errors.py`

**Tests** — 66 new tests across 3 files:
- `test_referrer_model.py` (29 tests) — serialization, filtering, merging, edge cases
- `test_referrer_operations.py` (24 tests) — HTTP mocking, server/client-side filtering, pagination, error mapping
- `test_referrer_cli.py` (11 tests) — CLI output, JSON mode, tag rejection, `--all` flag, error handling, file output

### 3. ACR Auth Fix (commit 4769d84)

Fixed two issues that caused `regshape` to fail against Azure Container Registry with *"returned 401 without a WWW-Authenticate header"*:

**Case-insensitive header lookup**: `RegistryResponse.headers` is a plain `dict` (converted from `requests.CaseInsensitiveDict` via `dict(response.headers)`). ACR returns the header as `Www-Authenticate` (title-case), but the code looked for `WWW-Authenticate` (uppercase). Added `_get_header_ci()` helper for case-insensitive lookups.

**`/v2/` fallback probe**: Some registries only return `WWW-Authenticate` on `/v2/`, not on resource endpoints. Added `AuthMiddleware._probe_v2_challenge()` that issues `GET /v2/` to obtain the challenge when the initial 401 lacks it. Same logic added to the legacy (non-middleware) path.

**Tests** — 9 new tests in `TestAuthV2Fallback`:
- Middleware: successful fallback, probe also missing, probe returns 200, no fallback when present, title-case header, title-case in fallback
- Legacy: successful fallback, probe also missing, no fallback when present

---

## Files Changed

| File | Change |
|------|--------|
| `specs/operations/referrers.md` | New — operations spec |
| `specs/models/referrer.md` | New — model spec |
| `specs/cli/referrer.md` | New — CLI spec |
| `src/regshape/libs/errors.py` | Added `ReferrerError` |
| `src/regshape/libs/models/referrer.py` | New — `ReferrerList` dataclass |
| `src/regshape/libs/models/__init__.py` | Added `ReferrerList` export |
| `src/regshape/libs/referrers/__init__.py` | New — package init |
| `src/regshape/libs/referrers/operations.py` | New — referrer operations |
| `src/regshape/cli/referrer.py` | New — CLI referrer commands |
| `src/regshape/cli/main.py` | Registered `referrer` command |
| `src/regshape/libs/transport/middleware.py` | Added `_get_header_ci()`, `_probe_v2_challenge()` |
| `src/regshape/libs/transport/client.py` | Added `/v2/` fallback in legacy path |
| `src/regshape/tests/test_referrer_model.py` | New — 29 tests |
| `src/regshape/tests/test_referrer_operations.py` | New — 24 tests |
| `src/regshape/tests/test_referrer_cli.py` | New — 11 tests |
| `src/regshape/tests/test_client_middleware_integration.py` | Added 9 auth fallback tests |

## Testing

- 75 new tests (66 referrers + 9 auth fallback), all passing
- Full test suite: no regressions introduced
- Manually verified against Azure Container Registry (`acrtsmbasicsku.azurecr.io`)
