### PR TITLE
Enhanced Telemetry and Debug Features

### DIFF
--- a/specs/telemetry-enhancements.md
+++ b/specs/telemetry-enhancements.md
@@ -1,0 +1,702 @@
+# Enhanced Telemetry and Debug Features
+
+## Overview
+
+This spec defines enhancements to the existing telemetry decorator infrastructure (`libs/decorators/`) to improve debug output, integrate with `--log-file`, support structured logging, add performance metrics, and introduce telemetry verbosity levels. The goal is to make RegShape's telemetry a first-class diagnostic tool for both interactive CLI use and automated test analysis.
+
+**GitHub Issue:** [#34 — Enhanced Telemetry and Debug Features](https://github.com/toddysm/regshape/issues/34)
+
+## Table of Contents
+
+- [1. Current State](#1-current-state)
+- [2. Log File Integration](#2-log-file-integration)
+- [3. Enhanced Debug-Calls Formatting](#3-enhanced-debug-calls-formatting)
+- [4. Break Mode Logging Integration](#4-break-mode-logging-integration)
+- [5. Structured Logging Output](#5-structured-logging-output)
+- [6. Performance Metrics Collection and Display](#6-performance-metrics-collection-and-display)
+- [7. Telemetry Verbosity Levels](#7-telemetry-verbosity-levels)
+- [8. Updated CLI Flags](#8-updated-cli-flags)
+- [9. Updated TelemetryConfig](#9-updated-telemetryconfig)
+- [10. Module Changes](#10-module-changes)
+- [11. Implementation Sequence](#11-implementation-sequence)
+- [12. Open Questions](#12-open-questions)
+
+---
+
+## 1. Current State
+
+The existing telemetry system (see `architecture.md` Section 8) provides three decorators:
+
+| Decorator | CLI Flag | Purpose |
+|-----------|----------|---------|
+| `@track_time` | `--time-methods` | Per-method execution timing |
+| `@track_scenario` | `--time-scenarios` | Multi-step workflow timing |
+| `@debug_call` | `--debug-calls` | HTTP request/response header logging (curl -v style) |
+
+All telemetry output currently goes to `stderr` via `TelemetryConfig.output`. The global `--log-file` option exists in `cli/main.py` but is **not wired** into the telemetry system — it is stored in the Click context but never consumed.
+
+### Gaps Addressed by This Spec
+
+1. `--log-file` has no effect on telemetry output.
+2. `--debug-calls` shows headers only — no response body preview, no per-call timing, no content-length summary.
+3. No integration between break mode rule application and telemetry output.
+4. No machine-readable (JSON) telemetry output format.
+5. No aggregate performance metrics (request count, bytes transferred, error/retry counts).
+6. Telemetry flags are binary (on/off) with no way to control detail level.
+
+---
+
+## 2. Log File Integration
+
+### Requirement
+
+When `--log-file <path>` is specified, **all telemetry output** (timing blocks, debug-calls, performance metrics) is written to the specified file **in addition to** stderr. This allows users to capture diagnostic data for later analysis while still seeing output interactively.
+
+### Design
+
+`TelemetryConfig` gains a `log_file_path` field. When set, `configure_telemetry()` opens the file for writing and stores the file handle in a new `log_file` field. A new helper, `telemetry_write()`, replaces direct `print(..., file=out)` calls in the output modules and writes to both `output` (stderr) and `log_file` (when present).
+
+```python
+@dataclass
+class TelemetryConfig:
+    # ... existing fields ...
+    log_file_path: Optional[str] = None
+    log_file: Optional[IO] = field(default=None, repr=False)
+```
+
+### Wiring
+
+The `@telemetry_options` decorator in `libs/decorators/__init__.py` already consumes CLI kwargs before forwarding to the command. It will be extended to read the `--log-file` value from the Click context (`ctx.obj["log_file"]`) and pass it into `TelemetryConfig`:
+
+```python
+@functools.wraps(func)
+def wrapper(*args, **kwargs):
+    ctx = click.get_current_context()
+    log_file_path = ctx.obj.get("log_file") if ctx.obj else None
+    configure_telemetry(TelemetryConfig(
+        time_methods_enabled=kwargs.pop("time_methods", False),
+        time_scenarios_enabled=kwargs.pop("time_scenarios", False),
+        debug_calls_enabled=kwargs.pop("debug_calls", False),
+        log_file_path=log_file_path,
+    ))
+    ...
+```
+
+### Output Routing
+
+A new function in `output.py`:
+
+```python
+def telemetry_write(line: str, out: IO = None, log_file: IO = None) -> None:
+    """Write a telemetry line to stderr and optionally to the log file.
+
+    :param line: Text to write (newline appended automatically).
+    :param out: Primary output stream (defaults to stderr).
+    :param log_file: Secondary output stream (log file), or None.
+    """
+    if out is None:
+        out = sys.stderr
+    print(line, file=out)
+    if log_file is not None:
+        print(line, file=log_file)
+```
+
+All existing `print(...)` calls in `output.py` and `call_details.py` are replaced with `telemetry_write()`.
+
+### File Lifecycle
+
+The log file is opened in **append mode** (`"a"`) when `configure_telemetry()` is called with a non-None `log_file_path`, and closed in the `finally` block of the `@telemetry_options` wrapper (alongside `flush_telemetry()`). Append mode ensures that consecutive commands don't overwrite previous output, which is useful when running a script of multiple `regshape` invocations.
+
+```python
+finally:
+    from regshape.libs.decorators.output import flush_telemetry
+    flush_telemetry()
+    cfg = get_telemetry_config()
+    if cfg.log_file is not None:
+        cfg.log_file.close()
+```
+
+---
+
+## 3. Enhanced Debug-Calls Formatting
+
+### Requirement
+
+Enhance `--debug-calls` to show richer per-call diagnostic information beyond the current curl-v header dump.
+
+### New Elements
+
+1. **Per-call elapsed time** — A `* Elapsed: 0.123s` line after the response block.
+2. **Response body preview** — Truncated first N bytes of the response body when the content type is text-based (JSON, plain text, HTML). Binary content types show `* Body: <binary, 4096 bytes>`.
+3. **Content-Length summary** — A `* Content-Length: 4096` line in the request block when a body is sent, and in the response summary.
+4. **Separator between calls** — A blank line between consecutive debug-call blocks for readability.
+
+### Updated Output Format
+
+```
+* Connected to registry.example.com port 443
+> PUT /v2/myrepo/manifests/latest HTTP/1.1
+> Host: registry.example.com
+> Content-Type: application/vnd.oci.image.manifest.v1+json
+> Content-Length: 1234
+>
+< HTTP/1.1 201 Created
+< Docker-Content-Digest: sha256:abc123...
+< Content-Length: 0
+<
+* Elapsed: 0.045s
+* Body: (empty)
+
+* Connected to registry.example.com port 443
+> GET /v2/myrepo/manifests/latest HTTP/1.1
+> Host: registry.example.com
+> Accept: application/vnd.oci.image.manifest.v1+json
+>
+< HTTP/1.1 200 OK
+< Content-Type: application/vnd.oci.image.manifest.v1+json
+< Content-Length: 1234
+<
+* Elapsed: 0.112s
+* Body: {"schemaVersion":2,"mediaType":"application/vnd.oci.image.manif...
+```
+
+### Implementation
+
+`format_curl_debug()` gains new parameters:
+
+```python
+def format_curl_debug(
+    method: str,
+    url: str,
+    req_headers: dict,
+    status_code: int,
+    reason: str,
+    resp_headers: dict,
+    out: IO = None,
+    *,
+    elapsed: Optional[float] = None,
+    resp_body: Optional[bytes] = None,
+    req_content_length: Optional[int] = None,
+    verbosity: int = 1,
+) -> None:
+```
+
+The `@debug_call` decorator wraps the underlying function call with `time.perf_counter()` to measure elapsed time, and extracts `resp_body` from the response object (limited to the first 200 bytes for preview).
+
+### Body Preview Rules
+
+| Content-Type Pattern | Preview |
+|---------------------|---------|
+| `application/json`, `*+json` | First 200 chars, UTF-8 decoded |
+| `text/*` | First 200 chars, UTF-8 decoded |
+| Binary / unknown | `<binary, N bytes>` |
+| Empty body (Content-Length: 0 or no body) | `(empty)` |
+
+Body preview is only shown at verbosity level ≥ 1 (see Section 7). The 200-char limit keeps output compact and avoids flooding the terminal with large manifests. At verbosity level 2, the full body is printed.
+
+---
+
+## 4. Break Mode Logging Integration
+
+### Requirement
+
+When break mode is active, telemetry output should capture:
+- Which break rules matched and were applied to each request.
+- What mutations were made (before/after for the mutated field).
+- Rule application included in the telemetry summary block.
+
+### Design
+
+The `BreakModeMiddleware` (when implemented) will append entries to a new `TelemetryConfig.break_rule_log` list as it applies rules. Each entry records the rule name, the target field, the action, and optionally the original and mutated values.
+
+```python
+@dataclass
+class BreakRuleEntry:
+    """Record of a single break rule application.
+
+    :param rule_name: Human-readable name of the BreakRule.
+    :param target: Mutation target (header, body, method, path, etc.).
+    :param action: Mutation action (replace, remove, corrupt, etc.).
+    :param original: Original value of the mutated field (redacted if sensitive).
+    :param mutated: New value after mutation (redacted if sensitive).
+    """
+    rule_name: str
+    target: str
+    action: str
+    original: Optional[str] = None
+    mutated: Optional[str] = None
+```
+
+```python
+@dataclass
+class TelemetryConfig:
+    # ... existing fields ...
+    break_rule_log: list[BreakRuleEntry] = field(default_factory=list)
+```
+
+### Debug-Calls Integration
+
+When `--debug-calls` is active and break rules were applied to the current request, the debug output includes a `* Break:` section before the response:
+
+```
+* Connected to registry.example.com port 443
+> PUT /v2/myrepo/manifests/latest HTTP/1.1
+> Host: registry.example.com
+> Content-Type: text/plain
+>
+* Break: invalid_content_type — replaced Content-Type
+*   original: application/vnd.oci.image.manifest.v1+json
+*   mutated:  text/plain
+* Break: skip_auth — removed Authorization
+<
+< HTTP/1.1 401 Unauthorized
+< Www-Authenticate: Bearer realm="..."
+<
+* Elapsed: 0.023s
+```
+
+### Telemetry Block Integration
+
+The telemetry summary block gains a `break` row type when break rule entries are present:
+
+```
+── telemetry ──────────────────────────────────────────────────────
+  scenario  manifest put                                  0.045s
+    method  push_manifest                                 0.044s
+     break  invalid_content_type                     1 applied
+     break  skip_auth                                1 applied
+───────────────────────────────────────────────────────────────────
+```
+
+After rendering, `break_rule_log` is cleared alongside `method_timings`.
+
+### Sensitive Value Redaction
+
+When a break rule mutates auth-related fields (`target == "auth"`, or `key` is a sensitive header), the `original` and `mutated` values in `BreakRuleEntry` are redacted using the existing `redact_header_value()` function before being stored.
+
+---
+
+## 5. Structured Logging Output
+
+### Requirement
+
+Support a machine-readable JSON format for telemetry output, suitable for automated analysis pipelines and test result post-processing.
+
+### CLI Flag
+
+A new `--telemetry-format` option controls the output format:
+
+| Value | Description |
+|-------|-------------|
+| `text` (default) | Current human-readable block format |
+| `json` | One JSON object per telemetry event, newline-delimited (NDJSON) |
+
+### TelemetryConfig Addition
+
+```python
+@dataclass
+class TelemetryConfig:
+    # ... existing fields ...
+    output_format: str = "text"   # "text" or "json"
+```
+
+### JSON Schema
+
+Each telemetry event is a self-contained JSON object emitted on a single line:
+
+#### Scenario Event
+
+```json
+{
+  "type": "scenario",
+  "name": "manifest get",
+  "elapsed_s": 0.523,
+  "methods": [
+    {"name": "get_manifest", "elapsed_s": 0.231},
+    {"name": "resolve_credentials", "elapsed_s": 0.045}
+  ],
+  "break_rules": [],
+  "timestamp": "2026-03-05T10:30:00.123Z"
+}
+```
+
+#### Debug-Call Event
+
+```json
+{
+  "type": "debug_call",
+  "request": {
+    "method": "GET",
+    "url": "https://registry.example.com/v2/myrepo/manifests/latest",
+    "headers": {"Accept": "application/vnd.oci.image.manifest.v1+json", "Authorization": "Bearer <redacted>"}
+  },
+  "response": {
+    "status_code": 200,
+    "reason": "OK",
+    "headers": {"Content-Type": "application/vnd.oci.image.manifest.v1+json", "Content-Length": "1234"},
+    "body_preview": "{\"schemaVersion\":2,...}",
+    "body_size": 1234
+  },
+  "elapsed_s": 0.112,
+  "break_rules_applied": [],
+  "timestamp": "2026-03-05T10:30:00.234Z"
+}
+```
+
+#### Performance Metrics Event
+
+```json
+{
+  "type": "metrics",
+  "total_requests": 3,
+  "total_elapsed_s": 0.523,
+  "total_bytes_sent": 1234,
+  "total_bytes_received": 5678,
+  "retries": 1,
+  "errors": 0,
+  "status_code_counts": {"200": 2, "401": 1},
+  "timestamp": "2026-03-05T10:30:00.345Z"
+}
+```
+
+### Rendering Path
+
+`output.py` gains a `_render_json()` counterpart to the existing text rendering functions. The `print_telemetry_block()` function checks `config.output_format` and dispatches to the appropriate renderer:
+
+```python
+def print_telemetry_block(
+    scenario_name, scenario_elapsed, method_timings, out=None,
+    *, break_entries=None, metrics=None
+):
+    config = get_telemetry_config()
+    if config.output_format == "json":
+        _render_json_block(scenario_name, scenario_elapsed, method_timings,
+                           break_entries, metrics, out, config.log_file)
+    else:
+        _render_text_block(scenario_name, scenario_elapsed, method_timings,
+                           break_entries, metrics, out, config.log_file)
+```
+
+---
+
+## 6. Performance Metrics Collection and Display
+
+### Requirement
+
+Aggregate and display performance metrics across the entire command invocation: request count, bytes transferred, status code distribution, retry counts, and error counts.
+
+### PerformanceMetrics Dataclass
+
+A new dataclass in `libs/decorators/__init__.py`:
+
+```python
+@dataclass
+class PerformanceMetrics:
+    """Aggregate metrics collected during a command invocation.
+
+    :param total_requests: Total number of HTTP requests made.
+    :param total_bytes_sent: Total request body bytes sent.
+    :param total_bytes_received: Total response body bytes received.
+    :param retries: Number of retried requests (e.g. 401 re-auth).
+    :param errors: Number of requests that resulted in 4xx/5xx status codes.
+    :param status_code_counts: Counter of status codes seen.
+    :param total_elapsed: Wall-clock time for all HTTP calls combined.
+    """
+    total_requests: int = 0
+    total_bytes_sent: int = 0
+    total_bytes_received: int = 0
+    retries: int = 0
+    errors: int = 0
+    status_code_counts: dict[int, int] = field(default_factory=dict)
+    total_elapsed: float = 0.0
+
+    def record_request(
+        self,
+        status_code: int,
+        bytes_sent: int = 0,
+        bytes_received: int = 0,
+        elapsed: float = 0.0,
+        is_retry: bool = False,
+    ) -> None:
+        """Record a single HTTP request into the aggregated metrics.
+
+        :param status_code: HTTP response status code.
+        :param bytes_sent: Request body size in bytes.
+        :param bytes_received: Response body size in bytes.
+        :param elapsed: Elapsed time in seconds for this request.
+        :param is_retry: Whether this request was a retry.
+        """
+        self.total_requests += 1
+        self.total_bytes_sent += bytes_sent
+        self.total_bytes_received += bytes_received
+        self.total_elapsed += elapsed
+        self.status_code_counts[status_code] = self.status_code_counts.get(status_code, 0) + 1
+        if is_retry:
+            self.retries += 1
+        if status_code >= 400:
+            self.errors += 1
+```
+
+### TelemetryConfig Addition
+
+```python
+@dataclass
+class TelemetryConfig:
+    # ... existing fields ...
+    metrics_enabled: bool = False
+    metrics: PerformanceMetrics = field(default_factory=PerformanceMetrics)
+```
+
+### Collection Point
+
+The `@debug_call` decorator is the natural collection point since it already wraps every HTTP call. When `metrics_enabled` is True, each call records into `config.metrics`:
+
+```python
+# Inside @debug_call wrapper, after the HTTP call returns:
+if config.metrics_enabled:
+    config.metrics.record_request(
+        status_code=result.status_code,
+        bytes_sent=req_content_length or 0,
+        bytes_received=int(result.headers.get('Content-Length', 0)),
+        elapsed=elapsed,
+    )
+```
+
+This means `--metrics` implies `--debug-calls` instrumentation internally. However, the two flags remain independent for output purposes: `--metrics` alone shows only the summary block, while `--debug-calls` shows per-call details. When both are active, the user sees both.
+
+### CLI Flag
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--metrics` | flag | false | Display aggregate performance metrics after the command completes. |
+
+### Display Format (Text)
+
+A new summary section at the end of the telemetry block:
+
+```
+── telemetry ──────────────────────────────────────────────────────
+  scenario  manifest get                                  0.523s
+    method  get_manifest                                  0.231s
+    method  resolve_credentials                           0.045s
+   metrics  requests: 3  sent: 1.2 KB  recv: 5.5 KB
+   metrics  status: 200×2  401×1  retries: 1  errors: 0
+───────────────────────────────────────────────────────────────────
+```
+
+### Display Format (JSON)
+
+See the `metrics` event type in Section 5.
+
+### Flush Lifecycle
+
+`flush_telemetry()` emits the metrics summary after the method timings, then resets `config.metrics` to a fresh `PerformanceMetrics()`.
+
+---
+
+## 7. Telemetry Verbosity Levels
+
+### Requirement
+
+Replace the binary on/off granularity with numeric verbosity levels that control how much detail each telemetry feature produces.
+
+### Levels
+
+| Level | Name | Description |
+|-------|------|-------------|
+| 0 | Off | Telemetry feature disabled (current default behavior) |
+| 1 | Normal | Standard output — same as current on behavior |
+| 2 | Verbose | Extended output — full response bodies, per-call timings inline with methods, header values untruncated |
+
+### How Verbosity Applies to Each Feature
+
+| Feature | Level 0 | Level 1 | Level 2 |
+|---------|---------|---------|---------|
+| `--time-methods` | No output | Method name + elapsed (current) | Method name + elapsed + call count if called multiple times |
+| `--time-scenarios` | No output | Scenario name + elapsed + nested methods (current) | Same + percentage breakdown per method |
+| `--debug-calls` | No output | Headers + elapsed + body preview (200 chars) | Headers + elapsed + full response body (unlimited) |
+| `--metrics` | No output | Summary line (request count, bytes, status codes) | Summary + per-request breakdown table |
+
+### CLI Mechanism
+
+The existing boolean flags are preserved for backwards compatibility. A new `--telemetry-verbosity` option provides fine-grained control:
+
+| Option | Short | Type | Default | Description |
+|--------|-------|------|---------|-------------|
+| `--telemetry-verbosity` | `-tv` | int | 1 | Verbosity level (0, 1, 2) for telemetry output when a telemetry flag is active. |
+
+When a boolean flag (e.g. `--time-methods`) is present **without** `--telemetry-verbosity`, level 1 is used. When `--telemetry-verbosity=2` is specified, any active telemetry flag uses level 2.
+
+### TelemetryConfig Addition
+
+```python
+@dataclass
+class TelemetryConfig:
+    # ... existing fields ...
+    verbosity: int = 1   # 0=off, 1=normal, 2=verbose
+```
+
+---
+
+## 8. Updated CLI Flags
+
+### Leaf-Command Telemetry Flags (via `@telemetry_options`)
+
+| Option | Short | Type | Default | Description |
+|--------|-------|------|---------|-------------|
+| `--time-methods` | | flag | false | Print execution time for individual method calls. |
+| `--time-scenarios` | | flag | false | Print execution time for multi-step workflows. |
+| `--debug-calls` | | flag | false | Print request/response details for each HTTP call. |
+| `--metrics` | | flag | false | Display aggregate performance metrics. |
+| `--telemetry-format` | | choice | text | Telemetry output format: `text` or `json`. |
+| `--telemetry-verbosity` | `-tv` | int | 1 | Verbosity level for telemetry output (0, 1, 2). |
+
+### Global Flag (in `cli/main.py`)
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--log-file` | path | Path for telemetry log file (append mode). Already exists; now wired to TelemetryConfig. |
+
+### Backwards Compatibility
+
+All existing flags and their default behavior are preserved. The new flags are additive. Running `regshape manifest get -i ref --time-methods` produces identical output to the current implementation.
+
+---
+
+## 9. Updated TelemetryConfig
+
+The full updated dataclass:
+
+```python
+@dataclass
+class TelemetryConfig:
+    """Runtime configuration for telemetry decorators.
+
+    :param time_methods_enabled: When True, @track_time accumulates per-method
+        timing entries.
+    :param time_scenarios_enabled: When True, @track_scenario renders the
+        telemetry summary block.
+    :param debug_calls_enabled: When True, @debug_call prints each HTTP
+        round-trip.
+    :param metrics_enabled: When True, aggregate performance metrics are
+        collected and displayed.
+    :param verbosity: Detail level for telemetry output (0=off, 1=normal,
+        2=verbose).
+    :param output_format: Output format — "text" (default) or "json".
+    :param output: Writable stream for telemetry output (defaults to stderr).
+    :param log_file_path: Optional file path for telemetry log output.
+    :param log_file: File handle for log_file_path (managed by telemetry_options).
+    :param method_timings: Accumulated (qualname, elapsed) pairs from @track_time.
+    :param break_rule_log: Break rule application records from BreakModeMiddleware.
+    :param metrics: Aggregate performance metrics.
+    """
+    time_methods_enabled: bool = False
+    time_scenarios_enabled: bool = False
+    debug_calls_enabled: bool = False
+    metrics_enabled: bool = False
+    verbosity: int = 1
+    output_format: str = "text"
+    output: IO = field(default_factory=lambda: sys.stderr)
+    log_file_path: Optional[str] = None
+    log_file: Optional[IO] = field(default=None, repr=False)
+    method_timings: list[tuple[str, float]] = field(default_factory=list)
+    break_rule_log: list['BreakRuleEntry'] = field(default_factory=list)
+    metrics: 'PerformanceMetrics' = field(default_factory=PerformanceMetrics)
+```
+
+---
+
+## 10. Module Changes
+
+### Files to Modify
+
+| File | Changes |
+|------|---------|
+| `libs/decorators/__init__.py` | Add `PerformanceMetrics`, `BreakRuleEntry` dataclasses; extend `TelemetryConfig` with new fields; update `telemetry_options` to add `--metrics`, `--telemetry-format`, `--telemetry-verbosity` options and wire `--log-file` from context; add log file open/close lifecycle. |
+| `libs/decorators/output.py` | Add `telemetry_write()` helper; update `print_telemetry_block()` to accept break entries and metrics, dispatch to text/JSON renderers; add `_render_json_block()` for JSON mode; update `flush_telemetry()` to emit metrics and close log file. |
+| `libs/decorators/call_details.py` | Update `format_curl_debug()` signature with `elapsed`, `resp_body`, `req_content_length`, `verbosity` params; add per-call timing line, body preview, content-length; add break rule `* Break:` lines; add metrics recording; update `@debug_call` to measure elapsed time, extract body preview, record metrics. |
+| `libs/decorators/timing.py` | No changes to core logic. `@track_time` is already minimal and correct. |
+| `libs/decorators/scenario.py` | Update `print_telemetry_block()` call to pass `break_entries` and `metrics`. |
+| `cli/main.py` | No changes (global `--log-file` is already stored in `ctx.obj`). |
+| CLI leaf commands | No changes (new options are injected by `@telemetry_options`). |
+
+### New File
+
+| File | Purpose |
+|------|---------|
+| `libs/decorators/metrics.py` | `PerformanceMetrics` dataclass and `BreakRuleEntry` dataclass, kept in a separate module to avoid bloating `__init__.py`. Exported from `__init__.py`. |
+
+### Test Files to Create/Modify
+
+| File | Changes |
+|------|---------|
+| `tests/test_telemetry_log_file.py` | Tests for log file creation, append mode, dual output (stderr + file), file close on cleanup. |
+| `tests/test_debug_calls_enhanced.py` | Tests for elapsed time line, body preview (JSON, text, binary, empty), content-length line, verbosity levels. |
+| `tests/test_telemetry_metrics.py` | Tests for `PerformanceMetrics.record_request()`, metrics rendering in text and JSON, flush lifecycle. |
+| `tests/test_telemetry_json_output.py` | Tests for JSON schema conformance of scenario, debug_call, and metrics events. |
+
+---
+
+## 11. Implementation Sequence
+
+Work is ordered to minimize risk and enable incremental testing.
+
+### Step 1: `PerformanceMetrics` and `BreakRuleEntry` Dataclasses
+
+Create `libs/decorators/metrics.py` with both dataclasses. Unit-test `PerformanceMetrics.record_request()`. Export from `libs/decorators/__init__.py`.
+
+### Step 2: Extend `TelemetryConfig`
+
+Add new fields to `TelemetryConfig`. No behavioral changes yet — new fields default to disabled/empty.
+
+### Step 3: Log File Integration
+
+1. Update `telemetry_options` to read `--log-file` from context and open the file.
+2. Add `telemetry_write()` to `output.py`.
+3. Replace `print()` calls with `telemetry_write()` in `output.py` and `call_details.py`.
+4. Add file close in the `finally` block.
+5. Test: verify dual output and file lifecycle.
+
+### Step 4: Enhanced Debug-Calls Formatting
+
+1. Extend `format_curl_debug()` signature.
+2. Update `@debug_call` to measure elapsed time and extract body preview.
+3. Add per-call timing line, body preview, and content-length lines.
+4. Test: verify new output elements appear.
+
+### Step 5: Performance Metrics Collection
+
+1. Add `--metrics` to `@telemetry_options`.
+2. Wire metrics recording into `@debug_call`.
+3. Add metrics rendering to `print_telemetry_block()` and `flush_telemetry()`.
+4. Test: verify metrics accuracy and rendering.
+
+### Step 6: Structured JSON Output
+
+1. Add `--telemetry-format` to `@telemetry_options`.
+2. Implement `_render_json_block()` in `output.py`.
+3. Update `format_curl_debug()` to emit JSON when format is `"json"`.
+4. Test: verify JSON schema conformance.
+
+### Step 7: Telemetry Verbosity Levels
+
+1. Add `--telemetry-verbosity` to `@telemetry_options`.
+2. Update rendering functions to respect verbosity levels.
+3. Test: verify each level produces expected detail.
+
+### Step 8: Break Mode Logging Integration
+
+1. Add `* Break:` output to `format_curl_debug()` (conditioned on `break_rule_log` being non-empty).
+2. Add `break` row type to `print_telemetry_block()`.
+3. Defer BreakModeMiddleware population of `break_rule_log` to the break mode implementation (separate issue).
+4. Test: verify rendering with synthetic `BreakRuleEntry` data.
+
+---
+
+## 12. Open Questions
+
+- [ ] Should `--log-file` in append mode include a session separator (e.g. timestamp header) between invocations?
+- [ ] Should `--telemetry-format json` emit one JSON object per event (NDJSON) or wrap all events in a single JSON array? NDJSON is simpler for streaming; an array is simpler for loading as a document. This spec assumes NDJSON.
+- [ ] Should `--metrics` automatically enable the internal instrumentation of `@debug_call` (without showing per-call output), or should it require `--debug-calls` to be explicitly set? This spec assumes `--metrics` enables internal instrumentation independently.
+- [ ] Should body preview in `--debug-calls` respect a configurable max-length, or is the fixed 200-char / unlimited (verbosity 2) split sufficient?
+- [ ] For `--telemetry-verbosity`, should per-feature verbosity overrides (e.g. `--debug-calls-verbosity 2 --time-methods-verbosity 1`) be supported, or is a single global verbosity level enough for v1?

--- a/src/regshape/libs/decorators/__init__.py
+++ b/src/regshape/libs/decorators/__init__.py
@@ -156,12 +156,35 @@ def telemetry_options(func: Callable) -> Callable:
         ctx = click.get_current_context()
         log_file_path = ctx.obj.get("log_file") if ctx.obj else None
 
+        verbosity = kwargs.pop("telemetry_verbosity", 1)
+
+        # Verbosity 0 means "off" — disable all telemetry feature flags
+        # so downstream decorators and renderers are no-ops.
+        if verbosity <= 0:
+            enabled_time_methods = False
+            enabled_time_scenarios = False
+            enabled_debug_calls = False
+            enabled_metrics = False
+        else:
+            enabled_time_methods = kwargs.pop("time_methods", False)
+            enabled_time_scenarios = kwargs.pop("time_scenarios", False)
+            enabled_debug_calls = kwargs.pop("debug_calls", False)
+            enabled_metrics = kwargs.pop("metrics", False)
+
+        # Still pop the flags from kwargs when verbosity=0 so they
+        # are not forwarded to the command callback.
+        if verbosity <= 0:
+            kwargs.pop("time_methods", None)
+            kwargs.pop("time_scenarios", None)
+            kwargs.pop("debug_calls", None)
+            kwargs.pop("metrics", None)
+
         config = TelemetryConfig(
-            time_methods_enabled=kwargs.pop("time_methods", False),
-            time_scenarios_enabled=kwargs.pop("time_scenarios", False),
-            debug_calls_enabled=kwargs.pop("debug_calls", False),
-            metrics_enabled=kwargs.pop("metrics", False),
-            verbosity=kwargs.pop("telemetry_verbosity", 1),
+            time_methods_enabled=enabled_time_methods,
+            time_scenarios_enabled=enabled_time_scenarios,
+            debug_calls_enabled=enabled_debug_calls,
+            metrics_enabled=enabled_metrics,
+            verbosity=verbosity,
             output_format=kwargs.pop("telemetry_format", "text"),
             log_file_path=log_file_path,
         )

--- a/src/regshape/libs/decorators/__init__.py
+++ b/src/regshape/libs/decorators/__init__.py
@@ -23,7 +23,9 @@ import click
 
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import Callable, IO
+from typing import Callable, IO, Optional
+
+from regshape.libs.decorators.metrics import PerformanceMetrics
 
 
 @dataclass
@@ -37,18 +39,33 @@ class TelemetryConfig:
         telemetry summary block at the end of the decorated workflow.
     :param debug_calls_enabled: When True, ``@debug_call`` prints each HTTP
         round-trip in ``curl -v`` style.
+    :param metrics_enabled: When True, aggregate performance metrics are
+        collected and displayed.
+    :param verbosity: Detail level for telemetry output (0=off, 1=normal,
+        2=verbose).
+    :param output_format: Output format — ``"text"`` (default) or ``"json"``.
     :param output: Writable stream for telemetry output (defaults to stderr so
         it does not interfere with structured stdout output).
+    :param log_file_path: Optional file path for telemetry log output.
+    :param log_file: File handle for log_file_path (managed by
+        telemetry_options).
     :param method_timings: Ordered list of ``(qualname, elapsed)`` pairs
         accumulated by ``@track_time`` during the current invocation. Consumed
         and cleared by ``@track_scenario`` (or by :func:`flush_telemetry` for
         commands that have no scenario wrapper).
+    :param metrics: Aggregate performance metrics.
     """
     time_methods_enabled: bool = False
     time_scenarios_enabled: bool = False
     debug_calls_enabled: bool = False
+    metrics_enabled: bool = False
+    verbosity: int = 1
+    output_format: str = "text"
     output: IO = field(default_factory=lambda: sys.stderr)
+    log_file_path: Optional[str] = None
+    log_file: Optional[IO] = field(default=None, repr=False)
     method_timings: list[tuple[str, float]] = field(default_factory=list)
+    metrics: PerformanceMetrics = field(default_factory=PerformanceMetrics)
 
 
 _telemetry_config: ContextVar[TelemetryConfig] = ContextVar(
@@ -99,6 +116,24 @@ def telemetry_options(func: Callable) -> Callable:
     :return: Wrapped callback with telemetry options registered.
     """
     @click.option(
+        "--telemetry-verbosity", "-tv",
+        type=click.IntRange(0, 2),
+        default=1,
+        help="Verbosity level for telemetry output (0=off, 1=normal, 2=verbose).",
+    )
+    @click.option(
+        "--telemetry-format",
+        type=click.Choice(["text", "json"], case_sensitive=False),
+        default="text",
+        help="Telemetry output format: text or json.",
+    )
+    @click.option(
+        "--metrics",
+        is_flag=True,
+        default=False,
+        help="Display aggregate performance metrics.",
+    )
+    @click.option(
         "--debug-calls",
         is_flag=True,
         default=False,
@@ -118,11 +153,24 @@ def telemetry_options(func: Callable) -> Callable:
     )
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        configure_telemetry(TelemetryConfig(
+        ctx = click.get_current_context()
+        log_file_path = ctx.obj.get("log_file") if ctx.obj else None
+
+        config = TelemetryConfig(
             time_methods_enabled=kwargs.pop("time_methods", False),
             time_scenarios_enabled=kwargs.pop("time_scenarios", False),
             debug_calls_enabled=kwargs.pop("debug_calls", False),
-        ))
+            metrics_enabled=kwargs.pop("metrics", False),
+            verbosity=kwargs.pop("telemetry_verbosity", 1),
+            output_format=kwargs.pop("telemetry_format", "text"),
+            log_file_path=log_file_path,
+        )
+
+        # Open log file in append mode if specified
+        if config.log_file_path:
+            config.log_file = open(config.log_file_path, "a")  # noqa: SIM115
+
+        configure_telemetry(config)
         try:
             result = func(*args, **kwargs)
         finally:
@@ -130,6 +178,8 @@ def telemetry_options(func: Callable) -> Callable:
             # runs even when the command calls sys.exit() (raises SystemExit)
             from regshape.libs.decorators.output import flush_telemetry
             flush_telemetry()
+            if config.log_file is not None:
+                config.log_file.close()
         return result
     return wrapper
 
@@ -141,11 +191,13 @@ def telemetry_options(func: Callable) -> Callable:
 from regshape.libs.decorators.sanitization import SENSITIVE_HEADERS, redact_header_value, redact_headers  # noqa: E402
 from regshape.libs.decorators.timing import track_time                                          # noqa: E402
 from regshape.libs.decorators.scenario import track_scenario                                    # noqa: E402
-from regshape.libs.decorators.call_details import debug_call, format_curl_debug, http_request  # noqa: E402
-from regshape.libs.decorators.output import flush_telemetry, print_telemetry_block             # noqa: E402
+from regshape.libs.decorators.call_details import debug_call, format_curl_debug, format_curl_debug_json, http_request  # noqa: E402
+from regshape.libs.decorators.output import flush_telemetry, print_telemetry_block, telemetry_write  # noqa: E402
+from regshape.libs.decorators.metrics import PerformanceMetrics                                # noqa: E402
 
 __all__ = [
     'TelemetryConfig',
+    'PerformanceMetrics',
     'configure_telemetry',
     'get_telemetry_config',
     'telemetry_options',
@@ -156,7 +208,9 @@ __all__ = [
     'track_scenario',
     'debug_call',
     'format_curl_debug',
+    'format_curl_debug_json',
     'http_request',
     'print_telemetry_block',
     'flush_telemetry',
+    'telemetry_write',
 ]

--- a/src/regshape/libs/decorators/call_details.py
+++ b/src/regshape/libs/decorators/call_details.py
@@ -206,8 +206,8 @@ def format_curl_debug_json(
             resp_ct = v
             break
 
-    body_size = len(resp_body) if resp_body else 0
-    preview = _body_preview(resp_body, resp_ct, verbosity) if resp_body else None
+    body_size = len(resp_body) if resp_body is not None else 0
+    preview = _body_preview(resp_body, resp_ct, verbosity) if resp_body is not None else None
 
     event = {
         "type": "debug_call",

--- a/src/regshape/libs/decorators/call_details.py
+++ b/src/regshape/libs/decorators/call_details.py
@@ -302,17 +302,24 @@ def debug_call(func):
             raw_content_length = result.headers.get('Content-Length')
             resp_content_length = None
             if raw_content_length is not None:
-                try:
-                    resp_content_length = int(raw_content_length)
-                except (ValueError, TypeError):
-                    resp_content_length = None
+            # When streaming is enabled, avoid materializing the full body to preserve streaming semantics.
+            is_streaming = bool(kwargs.get('stream'))
+            if not is_streaming and hasattr(result, 'content'):
+                resp_body = result.content
+
+            resp_content_length = int(result.headers.get('Content-Length', 0))
+            # In streaming mode, rely only on Content-Length (if present) for received bytes.
+            if is_streaming:
+                resp_bytes_received = resp_content_length or 0
+            else:
+                resp_bytes_received = resp_content_length or len(resp_body or b"")
 
             # Record metrics if enabled
             if config.metrics_enabled:
                 config.metrics.record_request(
                     status_code=result.status_code,
                     bytes_sent=req_content_length or 0,
-                    bytes_received=resp_content_length or len(resp_body or b""),
+                    bytes_received=resp_bytes_received,
                     elapsed=elapsed,
                 )
 

--- a/src/regshape/libs/decorators/call_details.py
+++ b/src/regshape/libs/decorators/call_details.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-:mod: `call_details` - Decorator for logging HTTP request/response headers
+:mod: `call_details` - Decorator for logging HTTP request/response details
 ===========================================================================
 
     module:: call_details
@@ -10,19 +10,61 @@
                :func:`format_curl_debug` helper. When ``--debug-calls`` is
                enabled, prints each HTTP round-trip in ``curl -v`` style to
                stderr for every HTTP call made through the transport layer.
+
+               Enhanced with per-call elapsed time, response body preview,
+               content-length summary, and metrics recording.
     moduleauthor:: ToddySM <toddysm@gmail.com>
 """
 
 import functools
 import inspect
+import json
 import sys
+import time
 
 import requests
 
-from typing import IO
+from datetime import datetime, timezone
+from typing import IO, Optional
 from urllib.parse import urlparse
 
 from regshape.libs.decorators.sanitization import redact_headers
+
+
+# Body preview limit at verbosity level 1; unlimited at level 2.
+_BODY_PREVIEW_LIMIT = 200
+
+
+def _body_preview(body: Optional[bytes], content_type: str, verbosity: int) -> str:
+    """Produce a body preview string based on content type and verbosity.
+
+    :param body: Raw response body bytes, or ``None``.
+    :param content_type: Content-Type header value.
+    :param verbosity: Telemetry verbosity level.
+    :return: Human-readable body preview string.
+    """
+    if body is None or len(body) == 0:
+        return "(empty)"
+
+    ct_lower = content_type.lower() if content_type else ""
+    is_text = (
+        "application/json" in ct_lower
+        or "+json" in ct_lower
+        or ct_lower.startswith("text/")
+    )
+
+    if not is_text:
+        return f"<binary, {len(body)} bytes>"
+
+    limit = None if verbosity >= 2 else _BODY_PREVIEW_LIMIT
+    try:
+        decoded = body.decode("utf-8", errors="replace")
+    except Exception:
+        return f"<binary, {len(body)} bytes>"
+
+    if limit is not None and len(decoded) > limit:
+        return decoded[:limit] + "..."
+    return decoded
 
 
 def format_curl_debug(
@@ -33,6 +75,12 @@ def format_curl_debug(
     reason: str,
     resp_headers: dict,
     out: IO = None,
+    *,
+    elapsed: Optional[float] = None,
+    resp_body: Optional[bytes] = None,
+    req_content_length: Optional[int] = None,
+    verbosity: int = 1,
+    log_file: IO = None,
 ) -> None:
     """
     Print one HTTP round-trip in ``curl -v`` style.
@@ -43,27 +91,21 @@ def format_curl_debug(
     Sensitive header values are redacted via
     :func:`~regshape.libs.decorators.sanitization.redact_headers`.
 
-    Example output::
-
-        * Connected to registry.example.com port 443
-        > GET /v2/ HTTP/1.1
-        > Host: registry.example.com
-        > User-Agent: regshape/0.1
-        >
-        < HTTP/1.1 401 Unauthorized
-        < Www-Authenticate: Bearer realm="https://auth.example.com/token"
-        <
-
     :param method: HTTP method string (e.g. ``"GET"``).
     :param url: Full request URL (scheme + host + path + query).
-    :param req_headers: Request headers dict. ``Host`` is emitted from the
-        parsed URL and filtered from this dict to avoid duplication.
+    :param req_headers: Request headers dict.
     :param status_code: HTTP response status code.
-    :param reason: HTTP reason phrase (e.g. ``"OK"``, ``"Unauthorized"``).
-        Non-string or empty values are silently omitted.
+    :param reason: HTTP reason phrase.
     :param resp_headers: Response headers dict.
     :param out: Writable stream for output. Defaults to ``sys.stderr``.
+    :param elapsed: Per-call elapsed time in seconds, or ``None``.
+    :param resp_body: Response body bytes for preview, or ``None``.
+    :param req_content_length: Request body content-length, or ``None``.
+    :param verbosity: Telemetry verbosity level (1 or 2).
+    :param log_file: Secondary log file stream, or ``None``.
     """
+    from regshape.libs.decorators.output import telemetry_write
+
     if out is None:
         out = sys.stderr
 
@@ -78,43 +120,127 @@ def format_curl_debug(
     safe_resp = redact_headers(dict(resp_headers) if resp_headers else {})
 
     # Connection info
-    print(f"* Connected to {host} port {port}", file=out)
+    telemetry_write(f"* Connected to {host} port {port}", out, log_file)
 
     # Request block
-    print(f"> {method} {path} HTTP/1.1", file=out)
-    print(f"> Host: {host}", file=out)
+    telemetry_write(f"> {method} {path} HTTP/1.1", out, log_file)
+    telemetry_write(f"> Host: {host}", out, log_file)
     for key, value in safe_req.items():
         if key.lower() != "host":
-            print(f"> {key}: {value}", file=out)
-    print(">", file=out)
+            telemetry_write(f"> {key}: {value}", out, log_file)
+    if req_content_length is not None:
+        # Only add Content-Length line if not already in headers
+        if not any(k.lower() == "content-length" for k in safe_req):
+            telemetry_write(f"> Content-Length: {req_content_length}", out, log_file)
+    telemetry_write(">", out, log_file)
 
     # Response block
     reason_str = reason if isinstance(reason, str) and reason else ""
     status_line = f"< HTTP/1.1 {status_code}"
     if reason_str:
         status_line = f"{status_line} {reason_str}"
-    print(status_line, file=out)
+    telemetry_write(status_line, out, log_file)
     for key, value in safe_resp.items():
-        print(f"< {key}: {value}", file=out)
-    print("<", file=out)
+        telemetry_write(f"< {key}: {value}", out, log_file)
+    telemetry_write("<", out, log_file)
+
+    # Per-call elapsed time
+    if elapsed is not None:
+        telemetry_write(f"* Elapsed: {elapsed:.3f}s", out, log_file)
+
+    # Body preview
+    if verbosity >= 1:
+        resp_ct = ""
+        for k, v in (resp_headers or {}).items():
+            if k.lower() == "content-type":
+                resp_ct = v
+                break
+        preview = _body_preview(resp_body, resp_ct, verbosity)
+        telemetry_write(f"* Body: {preview}", out, log_file)
+
+    # Separator between calls
+    telemetry_write("", out, log_file)
+
+
+def format_curl_debug_json(
+    method: str,
+    url: str,
+    req_headers: dict,
+    status_code: int,
+    reason: str,
+    resp_headers: dict,
+    out: IO = None,
+    *,
+    elapsed: Optional[float] = None,
+    resp_body: Optional[bytes] = None,
+    req_content_length: Optional[int] = None,
+    verbosity: int = 1,
+    log_file: IO = None,
+) -> None:
+    """Emit a single debug_call event as an NDJSON line.
+
+    :param method: HTTP method string.
+    :param url: Full request URL.
+    :param req_headers: Request headers dict.
+    :param status_code: HTTP response status code.
+    :param reason: HTTP reason phrase.
+    :param resp_headers: Response headers dict.
+    :param out: Writable stream for output.
+    :param elapsed: Per-call elapsed time in seconds, or ``None``.
+    :param resp_body: Response body bytes for preview, or ``None``.
+    :param req_content_length: Request body content-length, or ``None``.
+    :param verbosity: Telemetry verbosity level.
+    :param log_file: Secondary log file stream, or ``None``.
+    """
+    from regshape.libs.decorators.output import telemetry_write
+
+    if out is None:
+        out = sys.stderr
+
+    safe_req = redact_headers(dict(req_headers) if req_headers else {})
+    safe_resp = redact_headers(dict(resp_headers) if resp_headers else {})
+
+    resp_ct = ""
+    for k, v in (resp_headers or {}).items():
+        if k.lower() == "content-type":
+            resp_ct = v
+            break
+
+    body_size = len(resp_body) if resp_body else 0
+    preview = _body_preview(resp_body, resp_ct, verbosity) if resp_body else None
+
+    event = {
+        "type": "debug_call",
+        "request": {
+            "method": method,
+            "url": url,
+            "headers": safe_req,
+        },
+        "response": {
+            "status_code": status_code,
+            "reason": reason if isinstance(reason, str) else "",
+            "headers": safe_resp,
+            "body_preview": preview,
+            "body_size": body_size,
+        },
+        "elapsed_s": round(elapsed, 6) if elapsed is not None else None,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    if req_content_length is not None:
+        event["request"]["content_length"] = req_content_length
+
+    telemetry_write(json.dumps(event, separators=(",", ":")), out, log_file)
 
 
 def debug_call(func):
     """
     Decorator that prints each HTTP round-trip in ``curl -v`` style when
-    ``--debug-calls`` is enabled.
+    ``--debug-calls`` is enabled, and records metrics when ``--metrics`` is
+    enabled.
 
-    Designed to wrap ``RegistryClient.request()`` (or any function whose
-    signature contains ``method``, ``path``/``url``, and ``headers`` and that
-    returns an object with ``status_code``, ``reason``, and ``headers``
-    attributes).
-
-    When the decorated function is a bound method and ``self`` exposes a
-    ``config.base_url`` (or a top-level ``base_url``) attribute, the path is
-    combined with that base URL so that :func:`format_curl_debug` can always
-    emit a ``* Connected to`` line with the correct host and port.
-
-    When disabled, the decorator is a lightweight passthrough.
+    Enhanced with per-call elapsed time measurement, response body preview,
+    and automatic metrics recording.
 
     :param func: The function to wrap.
     :type func: callable
@@ -126,7 +252,8 @@ def debug_call(func):
         # Import here to avoid circular import at module load time
         from regshape.libs.decorators import get_telemetry_config
         config = get_telemetry_config()
-        if not config.debug_calls_enabled:
+
+        if not config.debug_calls_enabled and not config.metrics_enabled:
             return func(*args, **kwargs)
 
         # Extract request details from the bound function arguments
@@ -153,18 +280,63 @@ def debug_call(func):
         except (ValueError, TypeError):
             method, url, req_headers = 'UNKNOWN', 'UNKNOWN', {}
 
+        # Determine request content length from kwargs
+        req_content_length = None
+        data = kwargs.get('data') or params.get('data') if 'params' in dir() else None
+        if data is not None:
+            if isinstance(data, (bytes, str)):
+                req_content_length = len(data) if isinstance(data, bytes) else len(data.encode('utf-8'))
+
+        # Measure elapsed time
+        start = time.perf_counter()
         result = func(*args, **kwargs)
+        elapsed = time.perf_counter() - start
 
         if hasattr(result, 'status_code') and hasattr(result, 'headers'):
-            format_curl_debug(
-                method,
-                url,
-                req_headers,
-                result.status_code,
-                getattr(result, 'reason', ''),
-                dict(result.headers),
-                config.output,
-            )
+            # Extract response body for preview (limited read)
+            resp_body = None
+            if hasattr(result, 'content'):
+                resp_body = result.content
+
+            resp_content_length = int(result.headers.get('Content-Length', 0))
+
+            # Record metrics if enabled
+            if config.metrics_enabled:
+                config.metrics.record_request(
+                    status_code=result.status_code,
+                    bytes_sent=req_content_length or 0,
+                    bytes_received=resp_content_length or len(resp_body or b""),
+                    elapsed=elapsed,
+                )
+
+            # Emit debug output if enabled
+            if config.debug_calls_enabled:
+                if config.output_format == "json":
+                    format_curl_debug_json(
+                        method, url, req_headers,
+                        result.status_code,
+                        getattr(result, 'reason', ''),
+                        dict(result.headers),
+                        config.output,
+                        elapsed=elapsed,
+                        resp_body=resp_body,
+                        req_content_length=req_content_length,
+                        verbosity=config.verbosity,
+                        log_file=config.log_file,
+                    )
+                else:
+                    format_curl_debug(
+                        method, url, req_headers,
+                        result.status_code,
+                        getattr(result, 'reason', ''),
+                        dict(result.headers),
+                        config.output,
+                        elapsed=elapsed,
+                        resp_body=resp_body,
+                        req_content_length=req_content_length,
+                        verbosity=config.verbosity,
+                        log_file=config.log_file,
+                    )
 
         return result
     return wrapper
@@ -177,13 +349,6 @@ def http_request(url: str, method: str = "GET", headers: dict = None, **kwargs):
 
     Use this instead of calling ``requests.get`` / ``requests.request``
     directly whenever ``--debug-calls`` output is desired for that call site.
-    The parameter names (``url``, ``method``, ``headers``) match what
-    ``@debug_call`` introspects, so request/response details are logged
-    automatically without any manual instrumentation.
-
-    This is a temporary helper until the ``RegistryClient`` transport layer is
-    implemented, at which point ``@debug_call`` is applied directly to
-    ``RegistryClient.request()`` and this function is no longer needed.
 
     :param url: Full request URL.
     :param method: HTTP method (default ``"GET"``).

--- a/src/regshape/libs/decorators/call_details.py
+++ b/src/regshape/libs/decorators/call_details.py
@@ -257,6 +257,7 @@ def debug_call(func):
             return func(*args, **kwargs)
 
         # Extract request details from the bound function arguments
+        params = {}
         try:
             sig = inspect.signature(func)
             bound = sig.bind(*args, **kwargs)
@@ -280,9 +281,9 @@ def debug_call(func):
         except (ValueError, TypeError):
             method, url, req_headers = 'UNKNOWN', 'UNKNOWN', {}
 
-        # Determine request content length from kwargs
+        # Determine request content length from kwargs or bound params
         req_content_length = None
-        data = kwargs.get('data') or params.get('data') if 'params' in dir() else None
+        data = kwargs.get('data') if 'data' in kwargs else params.get('data')
         if data is not None:
             if isinstance(data, (bytes, str)):
                 req_content_length = len(data) if isinstance(data, bytes) else len(data.encode('utf-8'))
@@ -293,21 +294,21 @@ def debug_call(func):
         elapsed = time.perf_counter() - start
 
         if hasattr(result, 'status_code') and hasattr(result, 'headers'):
-            # Extract response body for preview (limited read)
+            # When streaming is enabled, avoid materializing the full body to preserve streaming semantics.
+            is_streaming = bool(kwargs.get('stream'))
             resp_body = None
-            if hasattr(result, 'content'):
+            if not is_streaming and hasattr(result, 'content'):
                 resp_body = result.content
 
             # Parse Content-Length defensively; fall back to body length if needed
             raw_content_length = result.headers.get('Content-Length')
             resp_content_length = None
             if raw_content_length is not None:
-            # When streaming is enabled, avoid materializing the full body to preserve streaming semantics.
-            is_streaming = bool(kwargs.get('stream'))
-            if not is_streaming and hasattr(result, 'content'):
-                resp_body = result.content
+                try:
+                    resp_content_length = int(raw_content_length)
+                except (ValueError, TypeError):
+                    pass
 
-            resp_content_length = int(result.headers.get('Content-Length', 0))
             # In streaming mode, rely only on Content-Length (if present) for received bytes.
             if is_streaming:
                 resp_bytes_received = resp_content_length or 0

--- a/src/regshape/libs/decorators/call_details.py
+++ b/src/regshape/libs/decorators/call_details.py
@@ -298,7 +298,14 @@ def debug_call(func):
             if hasattr(result, 'content'):
                 resp_body = result.content
 
-            resp_content_length = int(result.headers.get('Content-Length', 0))
+            # Parse Content-Length defensively; fall back to body length if needed
+            raw_content_length = result.headers.get('Content-Length')
+            resp_content_length = None
+            if raw_content_length is not None:
+                try:
+                    resp_content_length = int(raw_content_length)
+                except (ValueError, TypeError):
+                    resp_content_length = None
 
             # Record metrics if enabled
             if config.metrics_enabled:

--- a/src/regshape/libs/decorators/metrics.py
+++ b/src/regshape/libs/decorators/metrics.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+"""
+:mod: `metrics` - Aggregate performance metrics for telemetry
+==============================================================
+
+    module:: metrics
+    :platform: Unix, Windows
+    :synopsis: Provides :class:`PerformanceMetrics` for collecting aggregate
+               HTTP performance data during a command invocation.
+    moduleauthor:: ToddySM <toddysm@gmail.com>
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class PerformanceMetrics:
+    """Aggregate metrics collected during a command invocation.
+
+    :param total_requests: Total number of HTTP requests made.
+    :param total_bytes_sent: Total request body bytes sent.
+    :param total_bytes_received: Total response body bytes received.
+    :param retries: Number of retried requests (e.g. 401 re-auth).
+    :param errors: Number of requests that resulted in 4xx/5xx status codes.
+    :param status_code_counts: Counter of status codes seen.
+    :param total_elapsed: Wall-clock time for all HTTP calls combined.
+    """
+    total_requests: int = 0
+    total_bytes_sent: int = 0
+    total_bytes_received: int = 0
+    retries: int = 0
+    errors: int = 0
+    status_code_counts: dict[int, int] = field(default_factory=dict)
+    total_elapsed: float = 0.0
+
+    def record_request(
+        self,
+        status_code: int,
+        bytes_sent: int = 0,
+        bytes_received: int = 0,
+        elapsed: float = 0.0,
+        is_retry: bool = False,
+    ) -> None:
+        """Record a single HTTP request into the aggregated metrics.
+
+        :param status_code: HTTP response status code.
+        :param bytes_sent: Request body size in bytes.
+        :param bytes_received: Response body size in bytes.
+        :param elapsed: Elapsed time in seconds for this request.
+        :param is_retry: Whether this request was a retry.
+        """
+        self.total_requests += 1
+        self.total_bytes_sent += bytes_sent
+        self.total_bytes_received += bytes_received
+        self.total_elapsed += elapsed
+        self.status_code_counts[status_code] = (
+            self.status_code_counts.get(status_code, 0) + 1
+        )
+        if is_retry:
+            self.retries += 1
+        if status_code >= 400:
+            self.errors += 1

--- a/src/regshape/libs/decorators/output.py
+++ b/src/regshape/libs/decorators/output.py
@@ -6,24 +6,41 @@
 
     module:: output
     :platform: Unix, Windows
-    :synopsis: Provides :func:`print_telemetry_block` and
-               :func:`flush_telemetry` — the single rendering path for all
-               ``--time-methods`` and ``--time-scenarios`` output.
+    :synopsis: Provides :func:`print_telemetry_block`,
+               :func:`flush_telemetry`, and :func:`telemetry_write` — the
+               single rendering path for all telemetry output.
 
                All telemetry output is collected during a command invocation
                and emitted as a single delimited block at the end, keeping
-               stderr clean and easy to read.
+               stderr clean and easy to read.  When ``--telemetry-format json``
+               is active, output is emitted as newline-delimited JSON (NDJSON).
     moduleauthor:: ToddySM <toddysm@gmail.com>
 """
 
+import json
 import sys
 
-from typing import IO
+from datetime import datetime, timezone
+from typing import IO, Optional
 
 _BLOCK_WIDTH = 66
 _LABEL_COL = 12        # "  scenario  " / "    method  "
 _ELAPSED_WIDTH = 7     # " 0.523s" — right-justified
 _NAME_WIDTH = _BLOCK_WIDTH - _LABEL_COL - _ELAPSED_WIDTH  # 47
+
+
+def telemetry_write(line: str, out: IO = None, log_file: IO = None) -> None:
+    """Write a telemetry line to *out* and optionally to the log file.
+
+    :param line: Text to write (newline appended automatically).
+    :param out: Primary output stream (defaults to stderr).
+    :param log_file: Secondary output stream (log file), or ``None``.
+    """
+    if out is None:
+        out = sys.stderr
+    print(line, file=out)
+    if log_file is not None:
+        print(line, file=log_file)
 
 
 def _format_row(indent: str, label: str, name: str, elapsed: float) -> str:
@@ -43,29 +60,175 @@ def _format_row(indent: str, label: str, name: str, elapsed: float) -> str:
     return f"{label_cell:<{_LABEL_COL}}{name:<{_NAME_WIDTH}}{elapsed_str:>{_ELAPSED_WIDTH}}"
 
 
+def _format_info_row(indent: str, label: str, info: str) -> str:
+    """Format a telemetry row with an informational string instead of elapsed time.
+
+    :param indent: Leading whitespace for the label.
+    :param label: Row type label (e.g. ``"metrics"``).
+    :param info: Informational text to display.
+    :return: Formatted string.
+    """
+    label_cell = f"{indent}{label}"
+    return f"{label_cell:<{_LABEL_COL}}{info}"
+
+
+def _format_bytes(n: int) -> str:
+    """Format a byte count into a human-readable string.
+
+    :param n: Number of bytes.
+    :return: Formatted string (e.g. ``"1.2 KB"``, ``"3.4 MB"``).
+    """
+    if n < 1024:
+        return f"{n} B"
+    elif n < 1024 * 1024:
+        return f"{n / 1024:.1f} KB"
+    else:
+        return f"{n / (1024 * 1024):.1f} MB"
+
+
+def _render_text_block(
+    scenario_name: Optional[str],
+    scenario_elapsed: Optional[float],
+    method_timings: list[tuple[str, float]],
+    metrics,
+    out: IO,
+    log_file: Optional[IO],
+    verbosity: int,
+) -> None:
+    """Render the telemetry summary block in human-readable text format.
+
+    :param scenario_name: Scenario name or ``None``.
+    :param scenario_elapsed: Scenario elapsed time or ``None``.
+    :param method_timings: List of ``(qualname, elapsed)`` pairs.
+    :param metrics: :class:`PerformanceMetrics` instance or ``None``.
+    :param out: Primary output stream.
+    :param log_file: Secondary output stream or ``None``.
+    :param verbosity: Telemetry verbosity level (1 or 2).
+    """
+    prefix = "\u2500\u2500 telemetry "   # "── telemetry "
+    header = prefix + "\u2500" * (_BLOCK_WIDTH - len(prefix))
+    telemetry_write(header, out, log_file)
+
+    if scenario_name is not None and scenario_elapsed is not None:
+        telemetry_write(
+            _format_row("  ", "scenario", scenario_name, scenario_elapsed),
+            out, log_file,
+        )
+
+    for name, elapsed in method_timings:
+        telemetry_write(
+            _format_row("    ", "method", name, elapsed),
+            out, log_file,
+        )
+
+    # Metrics summary rows
+    if metrics is not None and metrics.total_requests > 0:
+        sent = _format_bytes(metrics.total_bytes_sent)
+        recv = _format_bytes(metrics.total_bytes_received)
+        telemetry_write(
+            _format_info_row(
+                "   ", "metrics",
+                f"requests: {metrics.total_requests}  sent: {sent}  recv: {recv}",
+            ),
+            out, log_file,
+        )
+        status_parts = [
+            f"{code}\u00d7{count}"
+            for code, count in sorted(metrics.status_code_counts.items())
+        ]
+        status_str = "  ".join(status_parts)
+        telemetry_write(
+            _format_info_row(
+                "   ", "metrics",
+                f"status: {status_str}  retries: {metrics.retries}  errors: {metrics.errors}",
+            ),
+            out, log_file,
+        )
+
+    telemetry_write("\u2500" * _BLOCK_WIDTH, out, log_file)
+
+
+def _render_json_block(
+    scenario_name: Optional[str],
+    scenario_elapsed: Optional[float],
+    method_timings: list[tuple[str, float]],
+    metrics,
+    out: IO,
+    log_file: Optional[IO],
+) -> None:
+    """Render the telemetry summary block as NDJSON events.
+
+    :param scenario_name: Scenario name or ``None``.
+    :param scenario_elapsed: Scenario elapsed time or ``None``.
+    :param method_timings: List of ``(qualname, elapsed)`` pairs.
+    :param metrics: :class:`PerformanceMetrics` instance or ``None``.
+    :param out: Primary output stream.
+    :param log_file: Secondary output stream or ``None``.
+    """
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    if scenario_name is not None:
+        event = {
+            "type": "scenario",
+            "name": scenario_name,
+            "elapsed_s": round(scenario_elapsed, 6) if scenario_elapsed else 0,
+            "methods": [
+                {"name": name, "elapsed_s": round(elapsed, 6)}
+                for name, elapsed in method_timings
+            ],
+            "timestamp": timestamp,
+        }
+        telemetry_write(json.dumps(event, separators=(",", ":")), out, log_file)
+    elif method_timings:
+        # Methods without a scenario — emit individual method events
+        for name, elapsed in method_timings:
+            event = {
+                "type": "method",
+                "name": name,
+                "elapsed_s": round(elapsed, 6),
+                "timestamp": timestamp,
+            }
+            telemetry_write(json.dumps(event, separators=(",", ":")), out, log_file)
+
+    if metrics is not None and metrics.total_requests > 0:
+        event = {
+            "type": "metrics",
+            "total_requests": metrics.total_requests,
+            "total_elapsed_s": round(metrics.total_elapsed, 6),
+            "total_bytes_sent": metrics.total_bytes_sent,
+            "total_bytes_received": metrics.total_bytes_received,
+            "retries": metrics.retries,
+            "errors": metrics.errors,
+            "status_code_counts": {
+                str(k): v
+                for k, v in sorted(metrics.status_code_counts.items())
+            },
+            "timestamp": timestamp,
+        }
+        telemetry_write(json.dumps(event, separators=(",", ":")), out, log_file)
+
+
 def print_telemetry_block(
     scenario_name: str | None,
     scenario_elapsed: float | None,
     method_timings: list[tuple[str, float]],
     out: IO = None,
+    *,
+    metrics=None,
 ) -> None:
     """Render one telemetry summary block to *out*.
 
     Emits nothing if there is no data (both *scenario_name* is ``None`` and
-    *method_timings* is empty).
+    *method_timings* is empty and *metrics* has no requests).
 
-    Block format::
+    Block format (text)::
 
         ── telemetry ──────────────────────────────────────────────────────
           scenario  auth login                                    0.523s
             method  _verify_credentials                           0.231s
             method  store_credentials                             0.045s
-        ───────────────────────────────────────────────────────────────────
-
-    When only methods are present (no enclosing scenario)::
-
-        ── telemetry ──────────────────────────────────────────────────────
-            method  _verify_credentials                           0.231s
+           metrics  requests: 3  sent: 1.2 KB  recv: 5.5 KB
+           metrics  status: 200×2  401×1  retries: 1  errors: 0
         ───────────────────────────────────────────────────────────────────
 
     :param scenario_name: Human-readable scenario name, or ``None`` if no
@@ -75,23 +238,28 @@ def print_telemetry_block(
     :param method_timings: Ordered list of ``(qualname, elapsed)`` pairs
         collected by ``@track_time`` during the invocation.
     :param out: Writable stream for output. Defaults to ``sys.stderr``.
+    :param metrics: :class:`PerformanceMetrics` instance or ``None``.
     """
+    from regshape.libs.decorators import get_telemetry_config
+    config = get_telemetry_config()
+
     if out is None:
-        out = sys.stderr
-    if not scenario_name and not method_timings:
+        out = config.output
+
+    has_metrics = metrics is not None and metrics.total_requests > 0
+    if not scenario_name and not method_timings and not has_metrics:
         return
 
-    prefix = "\u2500\u2500 telemetry "   # "── telemetry "
-    header = prefix + "\u2500" * (_BLOCK_WIDTH - len(prefix))
-    print(header, file=out)
-
-    if scenario_name is not None and scenario_elapsed is not None:
-        print(_format_row("  ", "scenario", scenario_name, scenario_elapsed), file=out)
-
-    for name, elapsed in method_timings:
-        print(_format_row("    ", "method", name, elapsed), file=out)
-
-    print("\u2500" * _BLOCK_WIDTH, file=out)
+    if config.output_format == "json":
+        _render_json_block(
+            scenario_name, scenario_elapsed, method_timings,
+            metrics, out, config.log_file,
+        )
+    else:
+        _render_text_block(
+            scenario_name, scenario_elapsed, method_timings,
+            metrics, out, config.log_file, config.verbosity,
+        )
 
 
 def flush_telemetry() -> None:
@@ -102,10 +270,23 @@ def flush_telemetry() -> None:
     leaf command returns. Handles the ``--time-methods``-only case where no
     ``@track_scenario`` decorator is present to trigger rendering.
 
-    Is a no-op when no timings have accumulated.
+    Also emits aggregate metrics if ``--metrics`` is enabled.
+
+    Is a no-op when no timings have accumulated and metrics are empty.
     """
     from regshape.libs.decorators import get_telemetry_config
     config = get_telemetry_config()
-    if config.method_timings:
-        print_telemetry_block(None, None, list(config.method_timings), config.output)
+
+    metrics = config.metrics if config.metrics_enabled else None
+    has_timings = bool(config.method_timings)
+    has_metrics = metrics is not None and metrics.total_requests > 0
+
+    if has_timings or has_metrics:
+        print_telemetry_block(
+            None, None, list(config.method_timings), config.output,
+            metrics=metrics,
+        )
         config.method_timings.clear()
+        if config.metrics_enabled:
+            from regshape.libs.decorators.metrics import PerformanceMetrics
+            config.metrics = PerformanceMetrics()

--- a/src/regshape/libs/decorators/output.py
+++ b/src/regshape/libs/decorators/output.py
@@ -171,7 +171,7 @@ def _render_json_block(
         event = {
             "type": "scenario",
             "name": scenario_name,
-            "elapsed_s": round(scenario_elapsed, 6) if scenario_elapsed else 0,
+            "elapsed_s": round(scenario_elapsed, 6) if scenario_elapsed is not None else None,
             "methods": [
                 {"name": name, "elapsed_s": round(elapsed, 6)}
                 for name, elapsed in method_timings

--- a/src/regshape/libs/decorators/scenario.py
+++ b/src/regshape/libs/decorators/scenario.py
@@ -59,10 +59,15 @@ def track_scenario(name: str):
                 result = func(*args, **kwargs)
             finally:
                 elapsed = time.perf_counter() - start
+                metrics = config.metrics if config.metrics_enabled else None
                 print_telemetry_block(
-                    name, elapsed, list(config.method_timings), config.output
+                    name, elapsed, list(config.method_timings), config.output,
+                    metrics=metrics,
                 )
                 config.method_timings.clear()
+                if config.metrics_enabled:
+                    from regshape.libs.decorators.metrics import PerformanceMetrics
+                    config.metrics = PerformanceMetrics()
             return result
         return wrapper
     return decorator

--- a/src/regshape/tests/test_debug_calls_enhanced.py
+++ b/src/regshape/tests/test_debug_calls_enhanced.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+"""Tests for enhanced --debug-calls formatting."""
+
+import io
+
+from regshape.libs.decorators import TelemetryConfig, configure_telemetry
+from regshape.libs.decorators.call_details import format_curl_debug, _body_preview
+
+
+class TestBodyPreview:
+    """Tests for the _body_preview helper."""
+
+    def test_empty_body(self):
+        assert _body_preview(None, "", 1) == "(empty)"
+
+    def test_empty_bytes(self):
+        assert _body_preview(b"", "application/json", 1) == "(empty)"
+
+    def test_json_body_truncated_at_verbosity_1(self):
+        body = b'{"key": "' + b'a' * 300 + b'"}'
+        result = _body_preview(body, "application/json", 1)
+        assert len(result) <= 203  # 200 + "..."
+        assert result.endswith("...")
+
+    def test_json_body_full_at_verbosity_2(self):
+        body = b'{"key": "' + b'a' * 300 + b'"}'
+        result = _body_preview(body, "application/json", 2)
+        assert "..." not in result
+        assert len(result) == len(body)
+
+    def test_text_plain_body(self):
+        body = b"Hello World"
+        result = _body_preview(body, "text/plain", 1)
+        assert result == "Hello World"
+
+    def test_binary_body(self):
+        body = b"\x00\x01\x02" * 100
+        result = _body_preview(body, "application/octet-stream", 1)
+        assert result == "<binary, 300 bytes>"
+
+    def test_unknown_content_type_treated_as_binary(self):
+        body = b"some data"
+        result = _body_preview(body, "application/x-custom", 1)
+        assert "<binary," in result
+
+    def test_json_subtype(self):
+        body = b'{"schema": 2}'
+        result = _body_preview(body, "application/vnd.oci.image.manifest.v1+json", 1)
+        assert result == '{"schema": 2}'
+
+    def test_short_json_not_truncated(self):
+        body = b'{"ok": true}'
+        result = _body_preview(body, "application/json", 1)
+        assert result == '{"ok": true}'
+        assert "..." not in result
+
+
+class TestFormatCurlDebugEnhanced:
+    """Tests for enhanced format_curl_debug output."""
+
+    def _capture(self, **kwargs):
+        buf = io.StringIO()
+        log = io.StringIO()
+        format_curl_debug(
+            method="GET",
+            url="https://registry.example.com/v2/myrepo/manifests/latest",
+            req_headers={"Accept": "application/json"},
+            status_code=200,
+            reason="OK",
+            resp_headers={"Content-Type": "application/json", "Content-Length": "42"},
+            out=buf,
+            log_file=log,
+            **kwargs,
+        )
+        return buf.getvalue(), log.getvalue()
+
+    def test_elapsed_line_present(self):
+        text, _ = self._capture(elapsed=0.123)
+        assert "* Elapsed: 0.123s" in text
+
+    def test_no_elapsed_when_none(self):
+        text, _ = self._capture(elapsed=None)
+        assert "* Elapsed:" not in text
+
+    def test_body_preview_present(self):
+        text, _ = self._capture(
+            resp_body=b'{"status": "ok"}',
+            verbosity=1,
+        )
+        assert '* Body: {"status": "ok"}' in text
+
+    def test_empty_body_preview(self):
+        text, _ = self._capture(resp_body=None, verbosity=1)
+        assert "* Body: (empty)" in text
+
+    def test_binary_body_preview(self):
+        text, _ = self._capture(
+            resp_body=b"\x00\x01\x02",
+            verbosity=1,
+        )
+        # resp_headers has Content-Type: application/json, so it decodes as text
+        # Let's test with proper binary content type
+        buf = io.StringIO()
+        format_curl_debug(
+            method="GET",
+            url="https://registry.example.com/v2/myrepo/blobs/sha256:abc",
+            req_headers={},
+            status_code=200,
+            reason="OK",
+            resp_headers={"Content-Type": "application/octet-stream"},
+            out=buf,
+            resp_body=b"\x00\x01\x02" * 100,
+            verbosity=1,
+        )
+        assert "<binary, 300 bytes>" in buf.getvalue()
+
+    def test_req_content_length_line(self):
+        text, _ = self._capture(req_content_length=1234)
+        assert "> Content-Length: 1234" in text
+
+    def test_no_duplicate_content_length(self):
+        """If Content-Length is already in headers, don't add it again."""
+        buf = io.StringIO()
+        format_curl_debug(
+            method="PUT",
+            url="https://registry.example.com/v2/myrepo/manifests/latest",
+            req_headers={"Content-Length": "1234"},
+            status_code=201,
+            reason="Created",
+            resp_headers={},
+            out=buf,
+            req_content_length=1234,
+        )
+        text = buf.getvalue()
+        assert text.count("Content-Length: 1234") == 1
+
+    def test_separator_between_calls(self):
+        """Blank line at the end of each debug block."""
+        text, _ = self._capture(elapsed=0.1, verbosity=1)
+        # Output ends with a blank line (separator for next call)
+        assert text.endswith("\n\n")
+
+    def test_dual_output_to_log_file(self):
+        text, log = self._capture(elapsed=0.1, verbosity=1)
+        assert "* Connected to" in text
+        assert "* Connected to" in log
+        assert "* Elapsed:" in text
+        assert "* Elapsed:" in log
+
+    def test_verbosity_2_full_body(self):
+        body = b'{"key": "' + b'x' * 500 + b'"}'
+        buf = io.StringIO()
+        format_curl_debug(
+            method="GET",
+            url="https://registry.example.com/v2/myrepo/manifests/latest",
+            req_headers={},
+            status_code=200,
+            reason="OK",
+            resp_headers={"Content-Type": "application/json"},
+            out=buf,
+            resp_body=body,
+            verbosity=2,
+        )
+        text = buf.getvalue()
+        assert "..." not in text
+        # Full body should be present
+        assert 'x' * 500 in text

--- a/src/regshape/tests/test_telemetry_json_output.py
+++ b/src/regshape/tests/test_telemetry_json_output.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+
+"""Tests for structured JSON telemetry output."""
+
+import io
+import json
+
+from regshape.libs.decorators import TelemetryConfig, configure_telemetry
+from regshape.libs.decorators.output import print_telemetry_block, flush_telemetry
+from regshape.libs.decorators.call_details import format_curl_debug_json
+from regshape.libs.decorators.metrics import PerformanceMetrics
+
+
+class TestScenarioJsonOutput:
+    """Tests for JSON-format scenario telemetry blocks."""
+
+    def test_scenario_event_schema(self):
+        buf = io.StringIO()
+        configure_telemetry(TelemetryConfig(output_format="json", output=buf))
+        print_telemetry_block(
+            "manifest get", 0.523,
+            [("get_manifest", 0.231), ("resolve_credentials", 0.045)],
+            buf,
+        )
+        line = buf.getvalue().strip()
+        event = json.loads(line)
+        assert event["type"] == "scenario"
+        assert event["name"] == "manifest get"
+        assert event["elapsed_s"] == 0.523
+        assert len(event["methods"]) == 2
+        assert event["methods"][0]["name"] == "get_manifest"
+        assert event["methods"][0]["elapsed_s"] == 0.231
+        assert "timestamp" in event
+
+    def test_method_only_events(self):
+        """Methods without a scenario emit individual method events."""
+        buf = io.StringIO()
+        configure_telemetry(TelemetryConfig(output_format="json", output=buf))
+        print_telemetry_block(
+            None, None,
+            [("func_a", 0.1), ("func_b", 0.2)],
+            buf,
+        )
+        lines = [l for l in buf.getvalue().strip().split('\n') if l]
+        assert len(lines) == 2
+        e1 = json.loads(lines[0])
+        e2 = json.loads(lines[1])
+        assert e1["type"] == "method"
+        assert e1["name"] == "func_a"
+        assert e2["type"] == "method"
+        assert e2["name"] == "func_b"
+
+    def test_empty_data_emits_nothing(self):
+        buf = io.StringIO()
+        configure_telemetry(TelemetryConfig(output_format="json", output=buf))
+        print_telemetry_block(None, None, [], buf)
+        assert buf.getvalue() == ""
+
+
+class TestMetricsJsonOutput:
+    """Tests for JSON-format metrics events."""
+
+    def test_metrics_event_schema(self):
+        buf = io.StringIO()
+        metrics = PerformanceMetrics()
+        metrics.record_request(200, bytes_sent=100, bytes_received=500, elapsed=0.1)
+        metrics.record_request(401, bytes_sent=0, bytes_received=0, elapsed=0.02)
+        metrics.record_request(200, bytes_sent=50, bytes_received=300, elapsed=0.15)
+
+        configure_telemetry(TelemetryConfig(output_format="json", output=buf))
+        print_telemetry_block(
+            "test scenario", 0.5,
+            [("some_method", 0.1)],
+            buf,
+            metrics=metrics,
+        )
+        lines = [l for l in buf.getvalue().strip().split('\n') if l]
+        assert len(lines) == 2  # scenario + metrics
+
+        metrics_event = json.loads(lines[1])
+        assert metrics_event["type"] == "metrics"
+        assert metrics_event["total_requests"] == 3
+        assert metrics_event["total_bytes_sent"] == 150
+        assert metrics_event["total_bytes_received"] == 800
+        assert metrics_event["retries"] == 0
+        assert metrics_event["errors"] == 1
+        assert metrics_event["status_code_counts"]["200"] == 2
+        assert metrics_event["status_code_counts"]["401"] == 1
+        assert "timestamp" in metrics_event
+
+    def test_no_metrics_event_when_empty(self):
+        buf = io.StringIO()
+        metrics = PerformanceMetrics()  # no requests recorded
+        configure_telemetry(TelemetryConfig(output_format="json", output=buf))
+        print_telemetry_block(
+            "test scenario", 0.5,
+            [("some_method", 0.1)],
+            buf,
+            metrics=metrics,
+        )
+        lines = [l for l in buf.getvalue().strip().split('\n') if l]
+        assert len(lines) == 1  # scenario only, no metrics
+
+
+class TestDebugCallJsonOutput:
+    """Tests for JSON-format debug_call events."""
+
+    def test_debug_call_event_schema(self):
+        buf = io.StringIO()
+        format_curl_debug_json(
+            method="GET",
+            url="https://registry.example.com/v2/myrepo/manifests/latest",
+            req_headers={"Accept": "application/json"},
+            status_code=200,
+            reason="OK",
+            resp_headers={"Content-Type": "application/json", "Content-Length": "42"},
+            out=buf,
+            elapsed=0.112,
+            resp_body=b'{"schemaVersion": 2}',
+            req_content_length=None,
+        )
+        line = buf.getvalue().strip()
+        event = json.loads(line)
+        assert event["type"] == "debug_call"
+        assert event["request"]["method"] == "GET"
+        assert event["request"]["url"] == "https://registry.example.com/v2/myrepo/manifests/latest"
+        assert event["response"]["status_code"] == 200
+        assert event["response"]["reason"] == "OK"
+        assert event["elapsed_s"] == 0.112
+        assert "timestamp" in event
+
+    def test_debug_call_body_preview_in_json(self):
+        buf = io.StringIO()
+        format_curl_debug_json(
+            method="GET",
+            url="https://registry.example.com/v2/test",
+            req_headers={},
+            status_code=200,
+            reason="OK",
+            resp_headers={"Content-Type": "application/json"},
+            out=buf,
+            resp_body=b'{"hello": "world"}',
+        )
+        event = json.loads(buf.getvalue().strip())
+        assert event["response"]["body_preview"] == '{"hello": "world"}'
+        assert event["response"]["body_size"] == 18
+
+    def test_debug_call_req_content_length_in_json(self):
+        buf = io.StringIO()
+        format_curl_debug_json(
+            method="PUT",
+            url="https://registry.example.com/v2/test",
+            req_headers={},
+            status_code=201,
+            reason="Created",
+            resp_headers={},
+            out=buf,
+            req_content_length=512,
+        )
+        event = json.loads(buf.getvalue().strip())
+        assert event["request"]["content_length"] == 512
+
+    def test_debug_call_redacts_auth_in_json(self):
+        buf = io.StringIO()
+        format_curl_debug_json(
+            method="GET",
+            url="https://registry.example.com/v2/",
+            req_headers={"Authorization": "Bearer my-secret-token"},
+            status_code=200,
+            reason="OK",
+            resp_headers={},
+            out=buf,
+        )
+        event = json.loads(buf.getvalue().strip())
+        assert "my-secret-token" not in event["request"]["headers"]["Authorization"]
+        assert "<redacted>" in event["request"]["headers"]["Authorization"]
+
+    def test_debug_call_json_dual_output(self):
+        buf = io.StringIO()
+        log = io.StringIO()
+        format_curl_debug_json(
+            method="GET",
+            url="https://registry.example.com/v2/",
+            req_headers={},
+            status_code=200,
+            reason="OK",
+            resp_headers={},
+            out=buf,
+            log_file=log,
+        )
+        assert buf.getvalue() == log.getvalue()
+        assert json.loads(buf.getvalue().strip())["type"] == "debug_call"
+
+
+class TestFlushTelemetryJson:
+    """Tests for flush_telemetry in JSON mode."""
+
+    def test_flush_emits_json_methods(self):
+        buf = io.StringIO()
+        configure_telemetry(TelemetryConfig(
+            time_methods_enabled=True,
+            output_format="json",
+            output=buf,
+            method_timings=[("my_func", 0.1)],
+        ))
+        flush_telemetry()
+        line = buf.getvalue().strip()
+        event = json.loads(line)
+        assert event["type"] == "method"
+        assert event["name"] == "my_func"
+
+    def test_flush_emits_json_metrics(self):
+        buf = io.StringIO()
+        metrics = PerformanceMetrics()
+        metrics.record_request(200, elapsed=0.1)
+        configure_telemetry(TelemetryConfig(
+            metrics_enabled=True,
+            output_format="json",
+            output=buf,
+            metrics=metrics,
+        ))
+        flush_telemetry()
+        line = buf.getvalue().strip()
+        event = json.loads(line)
+        assert event["type"] == "metrics"
+        assert event["total_requests"] == 1

--- a/src/regshape/tests/test_telemetry_log_file.py
+++ b/src/regshape/tests/test_telemetry_log_file.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+"""Tests for log file integration in telemetry."""
+
+import io
+import os
+import tempfile
+
+from regshape.libs.decorators import (
+    TelemetryConfig,
+    configure_telemetry,
+    get_telemetry_config,
+)
+from regshape.libs.decorators.output import (
+    flush_telemetry,
+    print_telemetry_block,
+    telemetry_write,
+)
+from regshape.libs.decorators.metrics import PerformanceMetrics
+
+
+class TestTelemetryWrite:
+    """Tests for the telemetry_write() helper."""
+
+    def test_writes_to_primary_stream(self):
+        buf = io.StringIO()
+        telemetry_write("hello", out=buf)
+        assert buf.getvalue() == "hello\n"
+
+    def test_writes_to_both_streams(self):
+        primary = io.StringIO()
+        secondary = io.StringIO()
+        telemetry_write("hello", out=primary, log_file=secondary)
+        assert primary.getvalue() == "hello\n"
+        assert secondary.getvalue() == "hello\n"
+
+    def test_none_log_file_is_safe(self):
+        buf = io.StringIO()
+        telemetry_write("hello", out=buf, log_file=None)
+        assert buf.getvalue() == "hello\n"
+
+    def test_defaults_to_stderr(self):
+        """telemetry_write with no args should not raise."""
+        # We can't easily capture stderr here, but we can verify no exception
+        telemetry_write("test line")
+
+
+class TestLogFileIntegration:
+    """Tests for log file creation, dual output, and lifecycle."""
+
+    def test_print_telemetry_block_writes_to_log_file(self):
+        """Telemetry block output goes to both primary and log file."""
+        primary = io.StringIO()
+        log = io.StringIO()
+        configure_telemetry(TelemetryConfig(
+            time_methods_enabled=True,
+            output=primary,
+            log_file=log,
+        ))
+        print_telemetry_block(
+            "test scenario", 1.234,
+            [("my_method", 0.5)],
+            primary,
+        )
+        primary_text = primary.getvalue()
+        log_text = log.getvalue()
+        assert "── telemetry" in primary_text
+        assert "test scenario" in primary_text
+        assert "── telemetry" in log_text
+        assert "test scenario" in log_text
+
+    def test_flush_telemetry_writes_to_log_file(self):
+        """flush_telemetry sends output to both primary and log file."""
+        primary = io.StringIO()
+        log = io.StringIO()
+        configure_telemetry(TelemetryConfig(
+            time_methods_enabled=True,
+            output=primary,
+            log_file=log,
+            method_timings=[("some_func", 0.1)],
+        ))
+        flush_telemetry()
+        assert "some_func" in primary.getvalue()
+        assert "some_func" in log.getvalue()
+
+    def test_log_file_append_mode(self):
+        """Log file opened via TelemetryConfig uses append mode."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log",
+                                          delete=False) as f:
+            f.write("existing content\n")
+            path = f.name
+
+        try:
+            # Simulate what telemetry_options does
+            log_fh = open(path, "a")
+            primary = io.StringIO()
+            configure_telemetry(TelemetryConfig(
+                time_methods_enabled=True,
+                output=primary,
+                log_file_path=path,
+                log_file=log_fh,
+                method_timings=[("appended_method", 0.2)],
+            ))
+            flush_telemetry()
+            log_fh.close()
+
+            with open(path) as f:
+                content = f.read()
+            assert "existing content" in content
+            assert "appended_method" in content
+        finally:
+            os.unlink(path)
+
+    def test_metrics_in_log_file(self):
+        """Metrics output is written to the log file."""
+        primary = io.StringIO()
+        log = io.StringIO()
+        metrics = PerformanceMetrics()
+        metrics.record_request(status_code=200, bytes_sent=100, bytes_received=500)
+        configure_telemetry(TelemetryConfig(
+            metrics_enabled=True,
+            output=primary,
+            log_file=log,
+            metrics=metrics,
+        ))
+        flush_telemetry()
+        assert "requests: 1" in primary.getvalue()
+        assert "requests: 1" in log.getvalue()

--- a/src/regshape/tests/test_telemetry_metrics.py
+++ b/src/regshape/tests/test_telemetry_metrics.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+"""Tests for PerformanceMetrics dataclass."""
+
+from regshape.libs.decorators.metrics import PerformanceMetrics
+
+
+class TestPerformanceMetricsRecordRequest:
+    """Tests for PerformanceMetrics.record_request()."""
+
+    def test_single_request_increments_count(self):
+        m = PerformanceMetrics()
+        m.record_request(status_code=200)
+        assert m.total_requests == 1
+
+    def test_single_request_records_bytes(self):
+        m = PerformanceMetrics()
+        m.record_request(status_code=200, bytes_sent=100, bytes_received=500)
+        assert m.total_bytes_sent == 100
+        assert m.total_bytes_received == 500
+
+    def test_single_request_records_elapsed(self):
+        m = PerformanceMetrics()
+        m.record_request(status_code=200, elapsed=0.123)
+        assert abs(m.total_elapsed - 0.123) < 1e-9
+
+    def test_single_request_records_status_code(self):
+        m = PerformanceMetrics()
+        m.record_request(status_code=200)
+        assert m.status_code_counts == {200: 1}
+
+    def test_multiple_requests_accumulate(self):
+        m = PerformanceMetrics()
+        m.record_request(status_code=200, bytes_sent=100, bytes_received=500, elapsed=0.1)
+        m.record_request(status_code=200, bytes_sent=200, bytes_received=300, elapsed=0.2)
+        m.record_request(status_code=404, bytes_sent=0, bytes_received=50, elapsed=0.05)
+        assert m.total_requests == 3
+        assert m.total_bytes_sent == 300
+        assert m.total_bytes_received == 850
+        assert abs(m.total_elapsed - 0.35) < 1e-9
+        assert m.status_code_counts == {200: 2, 404: 1}
+
+    def test_error_counted_for_4xx(self):
+        m = PerformanceMetrics()
+        m.record_request(status_code=400)
+        assert m.errors == 1
+
+    def test_error_counted_for_5xx(self):
+        m = PerformanceMetrics()
+        m.record_request(status_code=500)
+        assert m.errors == 1
+
+    def test_no_error_for_2xx(self):
+        m = PerformanceMetrics()
+        m.record_request(status_code=200)
+        assert m.errors == 0
+
+    def test_no_error_for_3xx(self):
+        m = PerformanceMetrics()
+        m.record_request(status_code=301)
+        assert m.errors == 0
+
+    def test_retry_flag(self):
+        m = PerformanceMetrics()
+        m.record_request(status_code=200, is_retry=True)
+        assert m.retries == 1
+        assert m.total_requests == 1
+
+    def test_retry_not_counted_by_default(self):
+        m = PerformanceMetrics()
+        m.record_request(status_code=200)
+        assert m.retries == 0
+
+    def test_fresh_instance_is_zeroed(self):
+        m = PerformanceMetrics()
+        assert m.total_requests == 0
+        assert m.total_bytes_sent == 0
+        assert m.total_bytes_received == 0
+        assert m.retries == 0
+        assert m.errors == 0
+        assert m.status_code_counts == {}
+        assert m.total_elapsed == 0.0


### PR DESCRIPTION
## Summary

Implements the enhanced telemetry design from `specs/telemetry-enhancements.md`, adding log file integration, richer debug output, structured JSON telemetry, performance metrics, and verbosity levels.

Closes #34

## Changes

### New Files
- **`libs/decorators/metrics.py`** — `PerformanceMetrics` dataclass with `record_request()` for aggregate HTTP metrics
- **`specs/telemetry-enhancements.md`** — Full design spec for all telemetry enhancements

### Modified Files
- **`libs/decorators/__init__.py`** — Extended `TelemetryConfig` with new fields; added `--metrics`, `--telemetry-format`, `--telemetry-verbosity` CLI options; wired `--log-file` from Click context; added log file open/close lifecycle
- **`libs/decorators/output.py`** — Added `telemetry_write()` dual-output helper; text and JSON renderers; metrics summary rows
- **`libs/decorators/call_details.py`** — Enhanced `format_curl_debug()` with per-call elapsed time, body preview, content-length; added `format_curl_debug_json()` for NDJSON; metrics recording in `@debug_call`
- **`libs/decorators/scenario.py`** — Updated `@track_scenario` to pass metrics and reset after rendering

### Test Files (604 new test lines)
- **`test_telemetry_log_file.py`** — Log file creation, append mode, dual output, file close lifecycle
- **`test_telemetry_metrics.py`** — `PerformanceMetrics.record_request()` accumulation, errors, retries
- **`test_debug_calls_enhanced.py`** — Body preview, elapsed time, content-length, verbosity levels
- **`test_telemetry_json_output.py`** — JSON schema conformance for scenario, method, metrics, and debug_call events

## Implementation Steps Completed (from spec)
1. `PerformanceMetrics` dataclass
2. Extended `TelemetryConfig`
3. Log file integration (`telemetry_write`, dual output, lifecycle)
4. Enhanced debug-calls formatting (elapsed, body preview, content-length)
5. Performance metrics collection and display
6. Structured JSON output (NDJSON)
7. Telemetry verbosity levels (0/1/2)

## Deferred
- **Step 8: Break mode logging integration** — `BreakRuleEntry` dataclass and `break_rule_log` rendering are deferred to a follow-up issue, as break mode middleware is not yet implemented.

## Testing
All 51 new tests pass. No regressions in existing tests.
