### PR TITLE
feat: OCI layout push and auth hardening

### DIFF
--- a/docs/guides/create-oci-layout.md
+++ b/docs/guides/create-oci-layout.md
@@ -41,7 +41,7 @@ State is automatically persisted between steps in a staging file
 ## Step 1 — Initialise the layout
 
 ```bash
-regshape layout init --output ./my-image
+regshape layout init --path ./my-image
 ```
 
 This creates the directory structure, writes the `oci-layout` marker,
@@ -63,7 +63,7 @@ content-addressed descriptor.
 
 ```bash
 regshape layout add layer \
-  --layout ./my-image \
+  --path ./my-image \
   --file ./layer.tar.gz
 ```
 
@@ -74,7 +74,7 @@ compresses it with gzip. You can override this with `--compress-format zstd`.
 ```bash
 # Force zstd compression for an uncompressed tar
 regshape layout add layer \
-  --layout ./my-image \
+  --path ./my-image \
   --file ./layer.tar \
   --compress-format zstd
 ```
@@ -84,7 +84,7 @@ layer at add time, or add/update them later with `layout annotate layer`.
 
 ```bash
 regshape layout add layer \
-  --layout ./my-image \
+  --path ./my-image \
   --file ./layer.tar.gz \
   --annotation org.opencontainers.image.created=2026-03-08 \
   --annotation com.example.layer.role=base
@@ -99,7 +99,7 @@ order they are added.
 
 ```bash
 regshape layout generate config \
-  --layout ./my-image \
+  --path ./my-image \
   --architecture amd64 \
   --os linux \
   --media-type application/vnd.oci.image.config.v1+json
@@ -123,7 +123,7 @@ Generated config sha256:abc123... (312 bytes)
 
 ```bash
 regshape layout generate manifest \
-  --layout ./my-image \
+  --path ./my-image \
   --ref-name latest \
   --media-type application/vnd.oci.image.manifest.v1+json
 ```
@@ -143,7 +143,7 @@ Generated manifest [latest] sha256:def456... (578 bytes)
 At any point you can inspect what has been staged:
 
 ```bash
-regshape layout status --layout ./my-image
+regshape layout status --path ./my-image
 ```
 
 ```
@@ -161,7 +161,7 @@ Add `--json` to any command for machine-readable output.
 ## Viewing the index
 
 ```bash
-regshape layout show --layout ./my-image
+regshape layout show --path ./my-image
 ```
 
 Prints `index.json` as pretty-printed JSON.
@@ -171,7 +171,7 @@ Prints `index.json` as pretty-printed JSON.
 ## Validating the layout
 
 ```bash
-regshape layout validate --layout ./my-image
+regshape layout validate --path ./my-image
 ```
 
 Checks that:
@@ -194,7 +194,7 @@ Merge (or replace) annotations on a staged layer without touching the blob:
 
 ```bash
 regshape layout annotate layer \
-  --layout ./my-image \
+  --path ./my-image \
   --index 0 \
   --annotation com.example.role=base
 ```
@@ -208,7 +208,7 @@ config blob is automatically deleted.
 
 ```bash
 regshape layout update config \
-  --layout ./my-image \
+  --path ./my-image \
   --architecture arm64
 ```
 
@@ -224,7 +224,7 @@ and `index.json` is updated atomically.
 
 ```bash
 regshape layout annotate manifest \
-  --layout ./my-image \
+  --path ./my-image \
   --annotation org.opencontainers.image.version=1.2.0
 ```
 
@@ -234,34 +234,34 @@ regshape layout annotate manifest \
 
 ```bash
 # 1. Initialise
-regshape layout init --output ./my-image
+regshape layout init --path ./my-image
 
 # 2. Add layers
 regshape layout add layer \
-  --layout ./my-image \
+  --path ./my-image \
   --file ./base.tar.gz \
   --media-type application/vnd.oci.image.layer.v1.tar+gzip
 
 regshape layout add layer \
-  --layout ./my-image \
+  --path ./my-image \
   --file ./app.tar.gz \
   --media-type application/vnd.oci.image.layer.v1.tar+gzip
 
 # 3. Generate config
 regshape layout generate config \
-  --layout ./my-image \
+  --path ./my-image \
   --architecture amd64 \
   --os linux \
   --media-type application/vnd.oci.image.config.v1+json
 
 # 4. Generate manifest
 regshape layout generate manifest \
-  --layout ./my-image \
+  --path ./my-image \
   --ref-name latest \
   --media-type application/vnd.oci.image.manifest.v1+json
 
 # 5. Validate
-regshape layout validate --layout ./my-image
+regshape layout validate --path ./my-image
 ```
 
 ---

--- a/specs/cli/layout-push.md
+++ b/specs/cli/layout-push.md
@@ -99,12 +99,17 @@ manifests. Each manifest is pushed by its digest, and if it carries an
    a. Read the manifest blob via `read_blob(layout, descriptor.digest)`.
    b. Parse the manifest to extract layer and config descriptors.
    c. **Upload blobs** — for each blob descriptor (layers + config):
-      - Read blob bytes via `read_blob(layout, blob.digest)`.
       - Unless `--force`: call `head_blob(client, repo, blob.digest)`.
-        If 2xx, print skip message and continue.
-      - Call `upload_blob(client, repo, data, blob.digest, blob.media_type)`
-        (or `upload_blob_chunked` when `--chunked`).
-      - Print confirmation with digest and size.
+        If 2xx, invoke skip callback and continue. If `BlobError` with
+        status 404 (or no status), treat as "not present"; re-raise any
+        other `BlobError`.
+      - For monolithic uploads: read blob bytes via
+        `read_blob(layout, blob.digest)` and call
+        `upload_blob(client, repo, data, blob.digest, blob.media_type)`.
+      - For chunked uploads (`--chunked`): open the blob file directly
+        from disk and call `upload_blob_chunked(...)` to stream without
+        loading the entire blob into memory.
+      - Invoke progress callback with digest and size.
    d. **Push manifest** — determine the reference:
       - If `--dest` included a tag and this is the only manifest: use
         that tag.
@@ -120,10 +125,14 @@ Steps 1-3 execute normally. For steps 5a–5d the command prints what it
 *would* do without making any network calls:
 
 ```
-[dry-run] Would upload blob sha256:aaa... (1048576 bytes)
-[dry-run] Would upload blob sha256:bbb... (312 bytes)
-[dry-run] Would push manifest sha256:ccc... as 'latest'
+[dry-run] Layout ./my-image -> registry.io/myrepo/myimage
+
+[dry-run] Would upload blob sha256:aaa...bbb (1.0 MB)
+[dry-run] Would upload blob sha256:ccc...ddd (312 B)
+[dry-run] Would push manifest sha256:eee...fff as 'latest'
 ```
+
+Digests and sizes are formatted the same way as in the normal push output.
 
 ---
 
@@ -131,17 +140,39 @@ Steps 1-3 execute normally. For steps 5a–5d the command prints what it
 
 ### Plain text (default)
 
-```
-Pushing layout ./my-image → registry.io/myrepo/myimage
+When stderr is a TTY, each blob upload is shown as a Click progress bar
+that completes in one step (per-byte streaming progress is not available
+from the library upload). When stderr is *not* a TTY, simple
+"Uploading / Uploaded" lines are printed instead.
 
-  Manifest [latest] sha256:def456... (1 of 1)
-    Layer  sha256:aaa... (1048576 bytes) uploading... done
-    Layer  sha256:bbb... (524288 bytes)  exists, skipping
-    Config sha256:ccc... (312 bytes)     uploading... done
-    Manifest sha256:def456... → latest   pushed
-
-Push complete: 1 manifest, 2 blobs uploaded, 1 blob skipped.
 ```
+Pushing layout ./my-image -> registry.io/myrepo/myimage
+
+  sha256:aaa...bbb (1.0 MB)  [####################################]  1048576/1048576
+  sha256:ccc...ddd (512.0 KB) exists, skipping
+  sha256:eee...fff (312 B)   [####################################]  312/312
+  Manifest sha256:def456...ghi -> latest  pushed
+
+Push complete: 1 manifest(s), 2 blob(s) uploaded, 1 blob(s) skipped.
+```
+
+Non-TTY output (e.g. piped to a file):
+
+```
+Pushing layout ./my-image -> registry.io/myrepo/myimage
+
+  Uploading sha256:aaa...bbb (1.0 MB)...
+  Uploaded  sha256:aaa...bbb
+  sha256:ccc...ddd (512.0 KB) exists, skipping
+  Uploading sha256:eee...fff (312 B)...
+  Uploaded  sha256:eee...fff
+  Manifest sha256:def456...ghi -> latest  pushed
+
+Push complete: 1 manifest(s), 2 blob(s) uploaded, 1 blob(s) skipped.
+```
+
+Digests are truncated to `sha256:` + 12 hex characters in plain-text
+output. Sizes use human-friendly units (B, KB, MB, GB).
 
 ### JSON (`--json`)
 
@@ -287,7 +318,7 @@ regshape layout push \
 
 The CLI command delegates to a library function in `libs/layout/operations.py`:
 
-### `push_layout(layout_path, client, repo, tag_override, force, chunked, chunk_size) -> PushResult`
+### `push_layout(layout_path, client, repo, tag_override, force, chunked, chunk_size, progress_callback) -> PushResult`
 
 **Parameters:**
 
@@ -299,6 +330,9 @@ The CLI command delegates to a library function in `libs/layout/operations.py`:
 - `force: bool` — Skip existence checks when `True`.
 - `chunked: bool` — Use chunked upload protocol when `True`.
 - `chunk_size: int` — Chunk size (only used when `chunked=True`).
+- `progress_callback: Callable | None` — Optional callable invoked as
+  `progress_callback(event, **kwargs)` for UI feedback. Events:
+  `"blob_start"`, `"blob_skip"`, `"blob_done"`, `"manifest_done"`.
 
 **Returns:** A `PushResult` (dataclass or dict) containing the per-manifest
 push report and summary statistics (manifests pushed, blobs uploaded, blobs
@@ -329,17 +363,19 @@ skipped, bytes uploaded).
 
 ## Progress Bars
 
-The CLI command displays progress bars (via Click's progress bar support) to
-give real-time feedback during uploads:
+The CLI command uses `click.progressbar()` to give visual feedback during
+uploads:
 
-- **Blob upload progress** — one progress bar per blob, indicating bytes
-  uploaded vs total size. Blobs that are skipped (already present) show a
-  skip message instead.
-- **Overall manifest progress** — a top-level progress bar tracking manifests
-  pushed out of total.
+- **Blob upload progress** — one progress bar per blob. The bar is opened
+  when the upload starts and completed in a single update when the upload
+  finishes (per-byte streaming progress is not currently available from the
+  library upload functions). Blobs that are skipped (already present) show
+  a skip message instead of a progress bar.
+- There is **no** overall manifest-level progress bar.
 
-In `--json` mode, progress bars are suppressed and only the final JSON result
-is printed. Progress bars are also suppressed when stdout is not a TTY.
+In `--json` mode, progress bars are suppressed and only the final JSON
+result is printed. Progress bars are also suppressed when stderr is not
+a TTY; simple text lines are printed instead (see Output Format above).
 
 ---
 
@@ -354,4 +390,8 @@ is printed. Progress bars are also suppressed when stdout is not a TTY.
   it and treat as "blob not present" rather than a fatal error.
 - When `--verbose` is set, print each HTTP request/response summary
   (handled automatically by the transport middleware and `--debug-calls`).
-- Progress bars use `click.progressbar()` for each blob upload.
+- Progress bars use `click.progressbar()` for each blob upload. The bar is
+  completed in one step because the library upload functions do not expose
+  per-byte progress callbacks.
+- Chunked uploads open the blob file directly from disk for streaming
+  instead of loading the entire blob into memory via `read_blob()`.

--- a/specs/cli/layout-push.md
+++ b/specs/cli/layout-push.md
@@ -334,6 +334,22 @@ skipped, bytes uploaded).
 
 ---
 
+## Progress Bars
+
+The CLI command displays progress bars (via Click's progress bar support) to
+give real-time feedback during uploads:
+
+- **Blob upload progress** — one progress bar per blob, indicating bytes
+  uploaded vs total size. Blobs that are skipped (already present) show a
+  skip message instead.
+- **Overall manifest progress** — a top-level progress bar tracking manifests
+  pushed out of total.
+
+In `--json` mode, progress bars are suppressed and only the final JSON result
+is printed. Progress bars are also suppressed when stdout is not a TTY.
+
+---
+
 ## Implementation Notes
 
 - Add `push` as a new Click command under the existing `layout` group in
@@ -348,3 +364,4 @@ skipped, bytes uploaded).
   it and treat as "blob not present" rather than a fatal error.
 - When `--verbose` is set, print each HTTP request/response summary
   (handled automatically by the transport middleware and `--debug-calls`).
+- Progress bars use `click.progressbar()` for each blob upload.

--- a/specs/cli/layout-push.md
+++ b/specs/cli/layout-push.md
@@ -52,7 +52,7 @@ regshape layout push [OPTIONS]
 
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
-| `--layout` | `-l` | path | required | Root directory of a valid, completed OCI Image Layout (must have at least one manifest in `index.json`) |
+| `--path` | `-p` | path | required | Root directory of a valid, completed OCI Image Layout (must have at least one manifest in `index.json`) |
 | `--dest` | `-d` | string | required | Destination image reference — `registry/repo` or `registry/repo:tag`. If a tag is included it overrides the `ref.name` annotation in `index.json` for single-manifest layouts. See [Reference Resolution](#reference-resolution). |
 | `--force` | | flag | `false` | Skip the `HEAD` existence check and upload every blob unconditionally |
 | `--chunked` | | flag | `false` | Use the chunked (streaming) upload protocol for blobs instead of monolithic |
@@ -217,47 +217,47 @@ Push complete: 1 manifest, 2 blobs uploaded, 1 blob skipped.
 ```bash
 # Basic push — single manifest with tag from ref.name annotation
 regshape layout push \
-  --layout ./my-image \
+  --path ./my-image \
   --dest registry.io/myrepo/myimage
 
 # Override the tag
 regshape layout push \
-  --layout ./my-image \
+  --path ./my-image \
   --dest registry.io/myrepo/myimage:v2.0
 
 # Force re-upload of all blobs (skip existence checks)
 regshape layout push \
-  --layout ./my-image \
+  --path ./my-image \
   --dest registry.io/myrepo/myimage:latest \
   --force
 
 # Use chunked uploads for large layers
 regshape layout push \
-  --layout ./my-image \
+  --path ./my-image \
   --dest registry.io/myrepo/myimage:latest \
   --chunked \
   --chunk-size 1048576
 
 # Dry-run to see what would be pushed
 regshape layout push \
-  --layout ./my-image \
+  --path ./my-image \
   --dest registry.io/myrepo/myimage:latest \
   --dry-run
 
 # Push to an insecure (HTTP) registry with verbose output
 regshape --insecure --verbose layout push \
-  --layout ./my-image \
+  --path ./my-image \
   --dest localhost:5000/myimage:latest
 
 # JSON output for scripting
 regshape layout push \
-  --layout ./my-image \
+  --path ./my-image \
   --dest registry.io/myrepo/myimage:latest \
   --json
 
 # Parallel blob uploads (4 concurrent)
 regshape layout push \
-  --layout ./my-image \
+  --path ./my-image \
   --dest registry.io/myrepo/myimage:latest \
   --concurrency 4
 ```
@@ -270,20 +270,20 @@ Build a layout and push it in one session:
 
 ```bash
 # Build the layout (offline)
-regshape layout init --output ./my-image
-regshape layout add layer --layout ./my-image --file ./rootfs.tar.gz
-regshape layout add layer --layout ./my-image --file ./app.tar.gz
+regshape layout init --path ./my-image
+regshape layout add layer --path ./my-image --file ./rootfs.tar.gz
+regshape layout add layer --path ./my-image --file ./app.tar.gz
 regshape layout generate config \
-  --layout ./my-image --architecture amd64 --os linux
+  --path ./my-image --architecture amd64 --os linux
 regshape layout generate manifest \
-  --layout ./my-image --ref-name latest
+  --path ./my-image --ref-name latest
 
 # Validate before pushing
-regshape layout validate --layout ./my-image
+regshape layout validate --path ./my-image
 
 # Push to registry
 regshape layout push \
-  --layout ./my-image \
+  --path ./my-image \
   --dest myregistry.azurecr.io/myapp:latest
 ```
 

--- a/specs/cli/layout-push.md
+++ b/specs/cli/layout-push.md
@@ -1,0 +1,350 @@
+# CLI: `layout push`
+
+## Overview
+
+The `layout push` command pushes the contents of a local OCI Image Layout
+directory to a remote OCI-compliant registry. It reads the layout's
+`index.json` to discover all manifests and their referenced blobs (layers
+and configs), uploads every blob, then pushes each manifest. The command
+reuses the existing `libs/blobs` and `libs/manifests` operations — no new
+network-level code is required.
+
+`layout push` is the natural next step after building a layout with the
+`init → add layer → generate config → generate manifest` pipeline. It bridges
+the offline layout world and the online registry world.
+
+### Push Algorithm
+
+For each manifest descriptor in `index.json`:
+
+```
+1.  Parse the manifest blob to extract its layer + config descriptors.
+2.  For each blob (layers first, then config):
+    a.  HEAD /v2/{repo}/blobs/{digest}  — check if already present.
+    b.  If 404 → upload the blob (monolithic or chunked).
+    c.  If 2xx  → skip (already exists).
+3.  PUT /v2/{repo}/manifests/{reference} — push the manifest.
+```
+
+If the index contains multiple manifests (multi-platform image), each is
+pushed individually. A future extension could wrap them in an index manifest;
+that is out of scope for this spec.
+
+### Blob Existence Check
+
+Before uploading each blob, the command issues a `HEAD` request to test
+whether the registry already has it. This avoids redundant uploads (common
+when layers are shared across images or when re-pushing after a partial
+failure). The existence check can be disabled with `--force` to
+unconditionally upload every blob.
+
+---
+
+## Usage
+
+```
+regshape layout push [OPTIONS]
+```
+
+---
+
+## Options
+
+| Option | Short | Type | Default | Description |
+|--------|-------|------|---------|-------------|
+| `--layout` | `-l` | path | required | Root directory of a valid, completed OCI Image Layout (must have at least one manifest in `index.json`) |
+| `--dest` | `-d` | string | required | Destination image reference — `registry/repo` or `registry/repo:tag`. If a tag is included it overrides the `ref.name` annotation in `index.json` for single-manifest layouts. See [Reference Resolution](#reference-resolution). |
+| `--force` | | flag | `false` | Skip the `HEAD` existence check and upload every blob unconditionally |
+| `--chunked` | | flag | `false` | Use the chunked (streaming) upload protocol for blobs instead of monolithic |
+| `--chunk-size` | | integer | `65536` | Chunk size in bytes when `--chunked` is enabled |
+| `--concurrency` | `-c` | integer | `1` | Number of parallel blob uploads (min 1, max 8). Default is sequential. |
+| `--dry-run` | | flag | `false` | Validate the layout and print what *would* be pushed without making any network calls |
+
+Global options `--insecure`, `--verbose`, `--json`, and the telemetry family
+(`--time-methods`, `--time-scenarios`, `--debug-calls`, `--metrics`,
+`--telemetry-format`, `--telemetry-verbosity`) are inherited from the parent
+groups and are all supported.
+
+---
+
+## Reference Resolution
+
+The `--dest` option follows the same `registry/repo[:tag]` format used
+by other regshape commands:
+
+| `--dest` value | Registry | Repo | Tag / Reference |
+|----------------|----------|------|-----------------|
+| `registry.io/myrepo/myimage` | `registry.io` | `myrepo/myimage` | Taken from the manifest's `org.opencontainers.image.ref.name` annotation; if absent, falls back to the manifest digest |
+| `registry.io/myrepo/myimage:v1.0` | `registry.io` | `myrepo/myimage` | `v1.0` (overrides the annotation for single-manifest layouts) |
+
+### Multi-manifest layouts
+
+When `index.json` contains more than one manifest and `--dest` includes a
+tag, the command exits with an error — a single tag cannot address multiple
+manifests. Each manifest is pushed by its digest, and if it carries an
+`org.opencontainers.image.ref.name` annotation, that tag is also created.
+
+---
+
+## Behaviour
+
+1. **Validate** — call `validate_layout(layout)`. Exit 1 on failure.
+2. **Read index** — call `read_index(layout)` to get the list of manifest
+   descriptors from `index.json`.
+3. **Resolve destination** — parse `--dest` via `parse_image_ref()` to
+   extract `(registry, repo, reference)`. If the reference component is a
+   tag and the index has more than one manifest, exit with an error.
+4. **Create client** — build `RegistryClient` with
+   `TransportConfig(registry=registry, insecure=ctx.obj["insecure"])`.
+5. **For each manifest descriptor** in `index.json.manifests`:
+   a. Read the manifest blob via `read_blob(layout, descriptor.digest)`.
+   b. Parse the manifest to extract layer and config descriptors.
+   c. **Upload blobs** — for each blob descriptor (layers + config):
+      - Read blob bytes via `read_blob(layout, blob.digest)`.
+      - Unless `--force`: call `head_blob(client, repo, blob.digest)`.
+        If 2xx, print skip message and continue.
+      - Call `upload_blob(client, repo, data, blob.digest, blob.media_type)`
+        (or `upload_blob_chunked` when `--chunked`).
+      - Print confirmation with digest and size.
+   d. **Push manifest** — determine the reference:
+      - If `--dest` included a tag and this is the only manifest: use
+        that tag.
+      - Otherwise: use the manifest's `org.opencontainers.image.ref.name`
+        annotation if present; fall back to the manifest digest.
+      - Call `push_manifest(client, repo, reference, manifest_bytes, descriptor.media_type)`.
+      - Print confirmation with digest.
+6. **Print summary** and exit 0.
+
+### Dry-run mode (`--dry-run`)
+
+Steps 1-3 execute normally. For steps 5a–5d the command prints what it
+*would* do without making any network calls:
+
+```
+[dry-run] Would upload blob sha256:aaa... (1048576 bytes)
+[dry-run] Would upload blob sha256:bbb... (312 bytes)
+[dry-run] Would push manifest sha256:ccc... as 'latest'
+```
+
+---
+
+## Output Format
+
+### Plain text (default)
+
+```
+Pushing layout ./my-image → registry.io/myrepo/myimage
+
+  Manifest [latest] sha256:def456... (1 of 1)
+    Layer  sha256:aaa... (1048576 bytes) uploading... done
+    Layer  sha256:bbb... (524288 bytes)  exists, skipping
+    Config sha256:ccc... (312 bytes)     uploading... done
+    Manifest sha256:def456... → latest   pushed
+
+Push complete: 1 manifest, 2 blobs uploaded, 1 blob skipped.
+```
+
+### JSON (`--json`)
+
+```json
+{
+  "layout_path": "./my-image",
+  "destination": "registry.io/myrepo/myimage",
+  "manifests": [
+    {
+      "digest": "sha256:def456...",
+      "reference": "latest",
+      "media_type": "application/vnd.oci.image.manifest.v1+json",
+      "blobs": [
+        {
+          "digest": "sha256:aaa...",
+          "size": 1048576,
+          "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "action": "uploaded"
+        },
+        {
+          "digest": "sha256:bbb...",
+          "size": 524288,
+          "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "action": "skipped"
+        },
+        {
+          "digest": "sha256:ccc...",
+          "size": 312,
+          "media_type": "application/vnd.oci.image.config.v1+json",
+          "action": "uploaded"
+        }
+      ],
+      "status": "pushed"
+    }
+  ],
+  "summary": {
+    "manifests_pushed": 1,
+    "blobs_uploaded": 2,
+    "blobs_skipped": 1,
+    "bytes_uploaded": 1048888
+  }
+}
+```
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All manifests and blobs pushed successfully |
+| 1 | Validation failure, authentication error, blob upload error, manifest push error, or I/O error |
+
+---
+
+## Error Messages
+
+| Scenario | Message |
+|----------|---------|
+| Layout not valid | `Error: layout validation failed: <details>` |
+| No manifests in index | `Error: index.json contains no manifests; run 'layout generate manifest' first` |
+| Tag supplied with multi-manifest index | `Error: --dest includes a tag but index.json has <N> manifests; omit the tag or push a single-manifest layout` |
+| Auth failure | `Error: authentication failed for <registry>: <details>` |
+| Blob upload failure | `Error: failed to upload blob <digest>: <details>` |
+| Manifest push failure | `Error: failed to push manifest <digest>: <details>` |
+| Missing blob on disk | `Error: blob <digest> referenced by manifest <manifest-digest> not found in layout` |
+
+---
+
+## Examples
+
+```bash
+# Basic push — single manifest with tag from ref.name annotation
+regshape layout push \
+  --layout ./my-image \
+  --dest registry.io/myrepo/myimage
+
+# Override the tag
+regshape layout push \
+  --layout ./my-image \
+  --dest registry.io/myrepo/myimage:v2.0
+
+# Force re-upload of all blobs (skip existence checks)
+regshape layout push \
+  --layout ./my-image \
+  --dest registry.io/myrepo/myimage:latest \
+  --force
+
+# Use chunked uploads for large layers
+regshape layout push \
+  --layout ./my-image \
+  --dest registry.io/myrepo/myimage:latest \
+  --chunked \
+  --chunk-size 1048576
+
+# Dry-run to see what would be pushed
+regshape layout push \
+  --layout ./my-image \
+  --dest registry.io/myrepo/myimage:latest \
+  --dry-run
+
+# Push to an insecure (HTTP) registry with verbose output
+regshape --insecure --verbose layout push \
+  --layout ./my-image \
+  --dest localhost:5000/myimage:latest
+
+# JSON output for scripting
+regshape layout push \
+  --layout ./my-image \
+  --dest registry.io/myrepo/myimage:latest \
+  --json
+
+# Parallel blob uploads (4 concurrent)
+regshape layout push \
+  --layout ./my-image \
+  --dest registry.io/myrepo/myimage:latest \
+  --concurrency 4
+```
+
+---
+
+## End-to-End Example
+
+Build a layout and push it in one session:
+
+```bash
+# Build the layout (offline)
+regshape layout init --output ./my-image
+regshape layout add layer --layout ./my-image --file ./rootfs.tar.gz
+regshape layout add layer --layout ./my-image --file ./app.tar.gz
+regshape layout generate config \
+  --layout ./my-image --architecture amd64 --os linux
+regshape layout generate manifest \
+  --layout ./my-image --ref-name latest
+
+# Validate before pushing
+regshape layout validate --layout ./my-image
+
+# Push to registry
+regshape layout push \
+  --layout ./my-image \
+  --dest myregistry.azurecr.io/myapp:latest
+```
+
+---
+
+## Library Function
+
+The CLI command delegates to a library function in `libs/layout/operations.py`:
+
+### `push_layout(layout_path, client, repo, tag_override, force, chunked, chunk_size, concurrency) -> PushResult`
+
+**Parameters:**
+
+- `layout_path: str | Path` — Root of the OCI Image Layout directory.
+- `client: RegistryClient` — Authenticated transport client.
+- `repo: str` — Target repository name (e.g. `"myrepo/myimage"`).
+- `tag_override: str | None` — If provided, overrides `ref.name` annotation
+  for single-manifest layouts.
+- `force: bool` — Skip existence checks when `True`.
+- `chunked: bool` — Use chunked upload protocol when `True`.
+- `chunk_size: int` — Chunk size (only used when `chunked=True`).
+- `concurrency: int` — Number of parallel blob uploads.
+
+**Returns:** A `PushResult` (dataclass or dict) containing the per-manifest
+push report and summary statistics (manifests pushed, blobs uploaded, blobs
+skipped, bytes uploaded).
+
+**Raises:**
+
+- `LayoutError` — Layout is invalid or incomplete.
+- `AuthError` — Authentication failure.
+- `BlobError` — Blob upload failure.
+- `ManifestError` — Manifest push failure.
+
+---
+
+## Dependencies
+
+- **Internal:**
+  - `libs/layout/operations.py` — `validate_layout`, `read_index`, `read_blob`
+  - `libs/blobs/operations.py` — `head_blob`, `upload_blob`, `upload_blob_chunked`
+  - `libs/manifests/operations.py` — `push_manifest`
+  - `libs/transport/client.py` — `RegistryClient`, `TransportConfig`
+  - `libs/refs.py` — `parse_image_ref`
+  - `libs/models/manifest.py` — `parse_manifest`
+  - `libs/errors.py` — `LayoutError`, `AuthError`, `BlobError`, `ManifestError`
+- **External:** none (no new third-party packages)
+
+---
+
+## Implementation Notes
+
+- Add `push` as a new Click command under the existing `layout` group in
+  `src/regshape/cli/layout.py`.
+- Implement `push_layout()` in `src/regshape/libs/layout/operations.py`
+  and export it from `libs/layout/__init__.py`.
+- Decorate the library function with `@track_scenario("layout push")`.
+- For `--concurrency > 1`, use `concurrent.futures.ThreadPoolExecutor`
+  to parallelise blob uploads. The manifest push is always sequential
+  (after all blobs are confirmed).
+- The `head_blob` call may return a `BlobError` with status 404 — catch
+  it and treat as "blob not present" rather than a fatal error.
+- When `--verbose` is set, print each HTTP request/response summary
+  (handled automatically by the transport middleware and `--debug-calls`).

--- a/specs/cli/layout-push.md
+++ b/specs/cli/layout-push.md
@@ -57,7 +57,6 @@ regshape layout push [OPTIONS]
 | `--force` | | flag | `false` | Skip the `HEAD` existence check and upload every blob unconditionally |
 | `--chunked` | | flag | `false` | Use the chunked (streaming) upload protocol for blobs instead of monolithic |
 | `--chunk-size` | | integer | `65536` | Chunk size in bytes when `--chunked` is enabled |
-| `--concurrency` | `-c` | integer | `1` | Number of parallel blob uploads (min 1, max 8). Default is sequential. |
 | `--dry-run` | | flag | `false` | Validate the layout and print what *would* be pushed without making any network calls |
 
 Global options `--insecure`, `--verbose`, `--json`, and the telemetry family
@@ -255,11 +254,6 @@ regshape layout push \
   --dest registry.io/myrepo/myimage:latest \
   --json
 
-# Parallel blob uploads (4 concurrent)
-regshape layout push \
-  --path ./my-image \
-  --dest registry.io/myrepo/myimage:latest \
-  --concurrency 4
 ```
 
 ---
@@ -293,7 +287,7 @@ regshape layout push \
 
 The CLI command delegates to a library function in `libs/layout/operations.py`:
 
-### `push_layout(layout_path, client, repo, tag_override, force, chunked, chunk_size, concurrency) -> PushResult`
+### `push_layout(layout_path, client, repo, tag_override, force, chunked, chunk_size) -> PushResult`
 
 **Parameters:**
 
@@ -305,7 +299,6 @@ The CLI command delegates to a library function in `libs/layout/operations.py`:
 - `force: bool` — Skip existence checks when `True`.
 - `chunked: bool` — Use chunked upload protocol when `True`.
 - `chunk_size: int` — Chunk size (only used when `chunked=True`).
-- `concurrency: int` — Number of parallel blob uploads.
 
 **Returns:** A `PushResult` (dataclass or dict) containing the per-manifest
 push report and summary statistics (manifests pushed, blobs uploaded, blobs
@@ -357,9 +350,6 @@ is printed. Progress bars are also suppressed when stdout is not a TTY.
 - Implement `push_layout()` in `src/regshape/libs/layout/operations.py`
   and export it from `libs/layout/__init__.py`.
 - Decorate the library function with `@track_scenario("layout push")`.
-- For `--concurrency > 1`, use `concurrent.futures.ThreadPoolExecutor`
-  to parallelise blob uploads. The manifest push is always sequential
-  (after all blobs are confirmed).
 - The `head_blob` call may return a `BlobError` with status 404 — catch
   it and treat as "blob not present" rather than a fatal error.
 - When `--verbose` is set, print each HTTP request/response summary

--- a/specs/cli/layout.md
+++ b/specs/cli/layout.md
@@ -52,7 +52,7 @@ Creates the `oci-layout` marker, `blobs/sha256/` directory, an empty
 
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
-| `--output` | `-o` | path | required | Directory path to initialise as an OCI Image Layout |
+| `--path` | `-p` | path | required | Directory path to initialise as an OCI Image Layout |
 
 #### Behaviour
 
@@ -85,7 +85,7 @@ Initialised OCI Image Layout at /path/to/layout
 #### Examples
 
 ```bash
-regshape layout init --output ./my-image
+regshape layout init --path ./my-image
 ```
 
 ---
@@ -114,7 +114,7 @@ or changed later with `layout annotate layer`.
 
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
-| `--layout` | `-l` | path | required | Root directory of an initialised OCI Image Layout |
+| `--path` | `-p` | path | required | Root directory of an initialised OCI Image Layout |
 | `--file` | `-f` | path | required | Path to the layer file |
 | `--compress-format` | | `gzip`\|`zstd` | `gzip` | Compression algorithm to apply when the input is not already a supported compressed tar |
 | `--media-type` | | string | inferred | Layer media type; if omitted, inferred from the (possibly compressed) content and confirmed interactively |
@@ -207,27 +207,27 @@ Staged layer:
 
 ```bash
 # Already compressed: use as-is, confirm media type interactively
-regshape layout add layer --layout ./my-image --file ./layer.tar.gz
+regshape layout add layer --path ./my-image --file ./layer.tar.gz
 
 # Raw tar: auto-compressed with gzip (default)
-regshape layout add layer --layout ./my-image --file ./layer.tar
+regshape layout add layer --path ./my-image --file ./layer.tar
 
 # Raw tar: compress with zstd instead
 regshape layout add layer \
-  --layout ./my-image \
+  --path ./my-image \
   --file ./layer.tar \
   --compress-format zstd
 
 # Add with layer annotations
 regshape layout add layer \
-  --layout ./my-image \
+  --path ./my-image \
   --file ./layer.tar.gz \
   --annotation org.opencontainers.image.created=2026-03-08 \
   --annotation com.example.layer.role=base
 
 # Explicit media type, no interactive prompt
 regshape layout add layer \
-  --layout ./my-image \
+  --path ./my-image \
   --file ./layer.tar.gz \
   --media-type application/vnd.oci.image.layer.v1.tar+gzip
 ```
@@ -255,7 +255,7 @@ These annotations are embedded in the manifest's `layers` array when
 
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
-| `--layout` | `-l` | path | required | Root directory of an initialised OCI Image Layout |
+| `--path` | `-p` | path | required | Root directory of an initialised OCI Image Layout |
 | `--index` | `-i` | integer | required | 0-based index of the staged layer to annotate (see `layout status`) |
 | `--annotation` | | key=value | required (≥1) | Annotation to add; may be specified multiple times |
 | `--replace` | | flag | `False` | Replace all existing annotations on this layer instead of merging |
@@ -304,13 +304,13 @@ Updated layer [0]:
 ```bash
 # Add an annotation to layer 0
 regshape layout annotate layer \
-  --layout ./my-image \
+  --path ./my-image \
   --index 0 \
   --annotation org.opencontainers.image.created=2026-03-08
 
 # Replace all annotations on layer 1
 regshape layout annotate layer \
-  --layout ./my-image \
+  --path ./my-image \
   --index 1 \
   --annotation com.example.role=patches \
   --replace
@@ -333,7 +333,7 @@ a new digest.
 
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
-| `--layout` | `-l` | path | required | Root directory of an initialised OCI Image Layout |
+| `--path` | `-p` | path | required | Root directory of an initialised OCI Image Layout |
 | `--annotation` | | key=value | required (≥1) | Manifest-level annotation to add; may be specified multiple times |
 | `--replace` | | flag | `False` | Replace all existing `manifest.annotations` instead of merging |
 
@@ -390,13 +390,13 @@ Updated manifest:
 ```bash
 # Add version and creation-date annotations
 regshape layout annotate manifest \
-  --layout ./my-image \
+  --path ./my-image \
   --annotation org.opencontainers.image.version=1.0.0 \
   --annotation org.opencontainers.image.created=2026-03-08
 
 # Replace all manifest annotations
 regshape layout annotate manifest \
-  --layout ./my-image \
+  --path ./my-image \
   --annotation org.opencontainers.image.title="My Image" \
   --replace
 ```
@@ -422,7 +422,7 @@ defaults and asks for confirmation.
 
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
-| `--layout` | `-l` | path | required | Root directory of an initialised OCI Image Layout |
+| `--path` | `-p` | path | required | Root directory of an initialised OCI Image Layout |
 | `--architecture` | | string | `amd64` | Target CPU architecture (proposed as default; confirmed interactively if not given) |
 | `--os` | | string | `linux` | Target operating system (proposed as default; confirmed interactively if not given) |
 | `--media-type` | | string | `application/vnd.oci.image.config.v1+json` | Config media type; proposed as default and confirmed interactively if not given |
@@ -488,11 +488,11 @@ Generated config:
 
 ```bash
 # Interactive prompts for all fields
-regshape layout generate config --layout ./my-image
+regshape layout generate config --path ./my-image
 
 # Provide all fields explicitly (no prompts)
 regshape layout generate config \
-  --layout ./my-image \
+  --path ./my-image \
   --architecture arm64 \
   --os linux \
   --media-type application/vnd.oci.image.config.v1+json \
@@ -518,7 +518,7 @@ annotations after generation, use `layout annotate manifest`.
 
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
-| `--layout` | `-l` | path | required | Root directory of an initialised OCI Image Layout |
+| `--path` | `-p` | path | required | Root directory of an initialised OCI Image Layout |
 | `--ref-name` | | string | `None` | Human-readable reference name (e.g. `latest`, `v1.2.3`); prompted if not given |
 | `--media-type` | | string | `application/vnd.oci.image.manifest.v1+json` | Manifest media type; proposed as default and confirmed interactively if not given |
 | `--annotation` | | key=value (multiple) | `None` | Annotations embedded in the manifest JSON |
@@ -590,11 +590,11 @@ Generated manifest:
 
 ```bash
 # Interactive prompts
-regshape layout generate manifest --layout ./my-image
+regshape layout generate manifest --path ./my-image
 
 # Explicit options
 regshape layout generate manifest \
-  --layout ./my-image \
+  --path ./my-image \
   --ref-name latest \
   --annotation org.opencontainers.image.version=1.0.0
 ```
@@ -621,7 +621,7 @@ a warning is printed advising you to re-run `layout generate manifest`.
 
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
-| `--layout` | `-l` | path | required | Root directory of an initialised OCI Image Layout |
+| `--path` | `-p` | path | required | Root directory of an initialised OCI Image Layout |
 | `--architecture` | | string | *(keep existing)* | New target CPU architecture; omit to keep current value |
 | `--os` | | string | *(keep existing)* | New target OS; omit to keep current value |
 | `--annotation` | | key=value | `None` | Annotation to merge into `config.Labels`; may be specified multiple times |
@@ -676,18 +676,18 @@ to reference the updated config.
 ```bash
 # Change only the architecture
 regshape layout update config \
-  --layout ./my-image \
+  --path ./my-image \
   --architecture arm64
 
 # Add labels to the config
 regshape layout update config \
-  --layout ./my-image \
+  --path ./my-image \
   --annotation org.opencontainers.image.version=1.0.0 \
   --annotation org.opencontainers.image.vendor=Acme
 
 # Replace all labels
 regshape layout update config \
-  --layout ./my-image \
+  --path ./my-image \
   --annotation org.opencontainers.image.title="My Image" \
   --replace-annotations
 ```
@@ -706,7 +706,7 @@ pipeline.
 
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
-| `--layout` | `-l` | path | required | Root directory of an OCI Image Layout |
+| `--path` | `-p` | path | required | Root directory of an OCI Image Layout |
 
 #### Behaviour
 
@@ -758,7 +758,7 @@ The raw contents of `.regshape-stage.json`:
 #### Examples
 
 ```bash
-regshape layout status --layout ./my-image
+regshape layout status --path ./my-image
 ```
 
 ---
@@ -771,7 +771,7 @@ Print the `index.json` of an OCI Image Layout.
 
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
-| `--layout` | `-l` | path | required | Root directory of an OCI Image Layout |
+| `--path` | `-p` | path | required | Root directory of an OCI Image Layout |
 
 #### Behaviour
 
@@ -810,7 +810,7 @@ Pretty-printed `index.json`:
 #### Examples
 
 ```bash
-regshape layout show --layout ./my-image
+regshape layout show --path ./my-image
 ```
 
 ---
@@ -823,7 +823,7 @@ Validate the structural and content integrity of an OCI Image Layout.
 
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
-| `--layout` | `-l` | path | required | Root directory of an OCI Image Layout to validate |
+| `--path` | `-p` | path | required | Root directory of an OCI Image Layout to validate |
 
 #### Behaviour
 
@@ -853,7 +853,7 @@ Error: blob sha256:deadbeef... referenced by index.json does not exist
 #### Examples
 
 ```bash
-regshape layout validate --layout ./my-image
+regshape layout validate --path ./my-image
 ```
 
 ---
@@ -864,11 +864,11 @@ Build an OCI Image Layout for a two-layer container image:
 
 ```bash
 # 1. Initialise the layout
-regshape layout init --output ./my-image
+regshape layout init --path ./my-image
 
 # 2. Add the base layer (raw tar — auto-compressed with gzip)
 regshape layout add layer \
-  --layout ./my-image \
+  --path ./my-image \
   --file ./rootfs.tar \
   --annotation com.example.layer.role=base
 # → "Input file is not compressed. Compressing with gzip..."
@@ -876,45 +876,45 @@ regshape layout add layer \
 
 # 3. Add a second layer (already gzip — used as-is)
 regshape layout add layer \
-  --layout ./my-image \
+  --path ./my-image \
   --file ./patches.tar.gz
 
 # 4. Add annotations to layer 1 after the fact
 regshape layout annotate layer \
-  --layout ./my-image \
+  --path ./my-image \
   --index 1 \
   --annotation com.example.layer.role=patches
 
 # 5. Check staging state
-regshape layout status --layout ./my-image
+regshape layout status --path ./my-image
 
 # 6. Generate the image config
 regshape layout generate config \
-  --layout ./my-image \
+  --path ./my-image \
   --architecture amd64 \
   --os linux
 
 # 7. (Optional) Modify the config to correct the architecture
 regshape layout update config \
-  --layout ./my-image \
+  --path ./my-image \
   --architecture arm64
 
 # 8. Generate the manifest and register in index.json
 regshape layout generate manifest \
-  --layout ./my-image \
+  --path ./my-image \
   --ref-name latest \
   --annotation org.opencontainers.image.version=1.0.0
 
 # 9. (Optional) Add more manifest annotations after the fact
 regshape layout annotate manifest \
-  --layout ./my-image \
+  --path ./my-image \
   --annotation org.opencontainers.image.created=2026-03-08
 
 # 10. Show the final index.json
-regshape layout show --layout ./my-image
+regshape layout show --path ./my-image
 
 # 11. Validate the layout
-regshape layout validate --layout ./my-image
+regshape layout validate --path ./my-image
 ```
 
 ---
@@ -923,8 +923,8 @@ regshape layout validate --layout ./my-image
 
 | Scenario | Message |
 |----------|---------|
-| `--output` already initialised | `Error: <path> is already an OCI Image Layout` |
-| `--layout` not an initialised layout | `Error: <path> is not an OCI Image Layout (missing oci-layout file)` |
+| `--path` already initialised | `Error: <path> is already an OCI Image Layout` |
+| `--path` not an initialised layout | `Error: <path> is not an OCI Image Layout (missing oci-layout file)` |
 | `--file` not found | `Error: File not found: <path>` |
 | Unknown extension, no `--media-type` given | `Error: cannot infer media type for '<ext>'; use --media-type` |
 | Compression error | `Error: failed to compress <path>: <reason>` |

--- a/src/regshape/cli/auth.py
+++ b/src/regshape/cli/auth.py
@@ -17,13 +17,12 @@ import sys
 import click
 import requests
 
-from regshape.libs.auth import registryauth
 from regshape.libs.auth.credentials import erase_credentials, resolve_credentials, store_credentials
 from regshape.libs.decorators import telemetry_options
-from regshape.libs.decorators.call_details import http_request
 from regshape.libs.decorators.scenario import track_scenario
 from regshape.libs.decorators.timing import track_time
 from regshape.libs.errors import AuthError
+from regshape.libs.transport.client import RegistryClient, TransportConfig
 
 
 @click.group()
@@ -70,11 +69,10 @@ def login(ctx, registry, username, password, password_stdin, docker_config):
     ~/.docker/config.json.  If both flags are omitted and no stored credentials
     are found, the command prompts interactively.
 
-    Verification is performed by issuing a direct HTTP GET to ``/v2/`` using
-    the ``requests`` client so that the full Bearer challenge/401-retry cycle
-    is executed automatically (required for Docker Hub and similar token-based
-    registries). This will migrate to ``RegistryClient`` once the transport
-    layer is available.
+    Verification is performed by issuing ``GET /v2/`` through
+    :class:`RegistryClient`, which handles the full Bearer challenge /
+    401-retry cycle (including the OAuth2 refresh-token exchange for
+    registries like ACR).
     """
     insecure = ctx.obj.get("insecure", False) if ctx.obj else False
 
@@ -163,14 +161,12 @@ def logout(ctx, registry, docker_config):
 def _verify_credentials(registry: str, username: str, password: str, insecure: bool = False) -> None:
     """
     Verify *username* and *password* against *registry* by issuing
-    ``GET /v2/`` and completing the full Bearer challenge cycle.
+    ``GET /v2/`` through :class:`RegistryClient`.
 
-    Uses the ``requests`` library directly with the existing
-    :func:`~regshape.libs.auth.registryauth.authenticate` helper so that the
-    ``RegistryClient`` (not yet constructed at CLI setup time) is not required.
-
-    The URL scheme defaults to HTTPS but switches to HTTP when *insecure* is
-    ``True`` (set via the global ``--insecure`` flag).
+    All authentication logic (401 challenge handling, WWW-Authenticate
+    parsing, Bearer token exchange including the OAuth2 refresh-token
+    fallback) is implemented inside the transport layer so that every
+    auth flow in the CLI goes through the same code path.
 
     :param registry: Registry hostname.
     :param username: Username to verify.
@@ -179,33 +175,23 @@ def _verify_credentials(registry: str, username: str, password: str, insecure: b
     :raises AuthError: If authentication is rejected.
     :raises requests.exceptions.RequestException: On connection errors.
     """
-    scheme = "http" if insecure else "https"
-    url = f"{scheme}://{registry}/v2/"
-
-    # First request — expect a challenge or immediate success
-    response = http_request(url, "GET", timeout=10)
+    config = TransportConfig(
+        registry=registry,
+        insecure=insecure,
+        username=username,
+        password=password,
+        timeout=10,
+    )
+    client = RegistryClient(config)
+    response = client.get("/v2/")
 
     if response.status_code == 200:
-        return  # No auth required (unusual but valid)
+        return
 
-    if response.status_code == 401:
-        www_auth = response.headers.get("WWW-Authenticate", "")
-        if not www_auth:
-            raise AuthError("Login failed", "Registry returned 401 without WWW-Authenticate header")
-
-        auth_value = registryauth.authenticate(www_auth, username, password)
-        auth_scheme = www_auth.split(" ")[0]
-        auth_headers = {"Authorization": f"{auth_scheme} {auth_value}"}
-
-        retry = http_request(url, "GET", headers=auth_headers, timeout=10)
-        if retry.status_code == 200:
-            return
-        raise AuthError(
-            "Login failed",
-            f"authentication rejected (status {retry.status_code})",
-        )
-
-    raise AuthError("Login failed", f"unexpected status {response.status_code}")
+    raise AuthError(
+        "Login failed",
+        f"authentication rejected (status {response.status_code})",
+    )
 
 
 def _error(registry: str, reason: str) -> None:

--- a/src/regshape/cli/layout.py
+++ b/src/regshape/cli/layout.py
@@ -158,8 +158,9 @@ def update():
 @layout.command("init")
 @telemetry_options
 @click.option(
-    "--output",
-    "-o",
+    "--path",
+    "-p",
+    "layout_path",
     required=True,
     type=click.Path(),
     metavar="DIR",
@@ -168,18 +169,18 @@ def update():
 @click.option("--json", "as_json", is_flag=True, default=False, help="Output JSON.")
 @click.pass_context
 @track_scenario("layout init")
-def init_cmd(ctx, output, as_json):
+def init_cmd(ctx, layout_path, as_json):
     """Initialise a new, empty OCI Image Layout at DIR."""
     try:
-        init_layout(output)
+        init_layout(layout_path)
     except (LayoutError, OSError) as exc:
-        _error(output, str(exc))
+        _error(layout_path, str(exc))
         sys.exit(1)
 
     if as_json:
-        click.echo(json.dumps({"layout_path": str(output)}, indent=2))
+        click.echo(json.dumps({"layout_path": str(layout_path)}, indent=2))
     else:
-        click.echo(f"Initialised OCI Image Layout at {output}")
+        click.echo(f"Initialised OCI Image Layout at {layout_path}")
 
 
 # ===========================================================================
@@ -190,7 +191,7 @@ def init_cmd(ctx, output, as_json):
 @add.command("layer")
 @telemetry_options
 @click.option(
-    "--layout", "-l", "layout_path",
+    "--path", "-p", "layout_path",
     required=True,
     type=click.Path(exists=True),
     metavar="DIR",
@@ -282,7 +283,7 @@ def add_layer(ctx, layout_path, layer_file, compress_format, media_type, raw_ann
 @annotate.command("layer")
 @telemetry_options
 @click.option(
-    "--layout", "-l", "layout_path",
+    "--path", "-p", "layout_path",
     required=True,
     type=click.Path(exists=True),
     metavar="DIR",
@@ -338,7 +339,7 @@ def annotate_layer(ctx, layout_path, layer_index, raw_annotations, replace, as_j
 @annotate.command("manifest")
 @telemetry_options
 @click.option(
-    "--layout", "-l", "layout_path",
+    "--path", "-p", "layout_path",
     required=True,
     type=click.Path(exists=True),
     metavar="DIR",
@@ -380,7 +381,7 @@ def annotate_manifest_cmd(ctx, layout_path, raw_annotations, replace, as_json):
 @generate.command("config")
 @telemetry_options
 @click.option(
-    "--layout", "-l", "layout_path",
+    "--path", "-p", "layout_path",
     required=True,
     type=click.Path(exists=True),
     metavar="DIR",
@@ -457,7 +458,7 @@ def generate_config_cmd(
 @generate.command("manifest")
 @telemetry_options
 @click.option(
-    "--layout", "-l", "layout_path",
+    "--path", "-p", "layout_path",
     required=True,
     type=click.Path(exists=True),
     metavar="DIR",
@@ -531,7 +532,7 @@ def generate_manifest_cmd(
 @update.command("config")
 @telemetry_options
 @click.option(
-    "--layout", "-l", "layout_path",
+    "--path", "-p", "layout_path",
     required=True,
     type=click.Path(exists=True),
     metavar="DIR",
@@ -612,7 +613,7 @@ def update_config_cmd(
 @layout.command("status")
 @telemetry_options
 @click.option(
-    "--layout", "-l", "layout_path",
+    "--path", "-p", "layout_path",
     required=True,
     type=click.Path(exists=True),
     metavar="DIR",
@@ -655,8 +656,8 @@ def status(ctx, layout_path, as_json):
 @layout.command("show")
 @telemetry_options
 @click.option(
-    "--layout",
-    "-l",
+    "--path",
+    "-p",
     "layout_path",
     required=True,
     type=click.Path(exists=True),
@@ -687,8 +688,8 @@ def show(ctx, layout_path):
 @layout.command("validate")
 @telemetry_options
 @click.option(
-    "--layout",
-    "-l",
+    "--path",
+    "-p",
     "layout_path",
     required=True,
     type=click.Path(exists=True),
@@ -738,7 +739,7 @@ def _format_size(size: int) -> str:
 @layout.command("push")
 @telemetry_options
 @click.option(
-    "--layout", "-l", "layout_path",
+    "--path", "-p", "layout_path",
     required=True,
     type=click.Path(exists=True),
     metavar="DIR",

--- a/src/regshape/cli/layout.py
+++ b/src/regshape/cli/layout.py
@@ -914,6 +914,14 @@ def _push_dry_run(layout_path, registry, repo, tag_override, as_json):
         _error(layout_path, "index.json contains no manifests")
         sys.exit(1)
 
+    if tag_override and len(index.manifests) > 1:
+        _error(
+            layout_path,
+            f"tag override supplied but index.json has {len(index.manifests)} manifests; "
+            "omit the tag or push a single-manifest layout",
+        )
+        sys.exit(1)
+
     from regshape.libs.layout import read_blob as _rb
 
     results = []

--- a/src/regshape/cli/layout.py
+++ b/src/regshape/cli/layout.py
@@ -857,6 +857,10 @@ def push_cmd(ctx, layout_path, dest, force, chunked, chunk_size, dry_run, as_jso
     except (AuthError, BlobError, ManifestError) as exc:
         _error(dest_display, str(exc))
         sys.exit(1)
+    finally:
+        if current_bar[0] is not None:
+            current_bar[0].__exit__(None, None, None)
+            current_bar[0] = None
 
     # --- Output ---
     if as_json:

--- a/src/regshape/cli/layout.py
+++ b/src/regshape/cli/layout.py
@@ -24,11 +24,12 @@ import click
 
 from regshape.libs.decorators import telemetry_options
 from regshape.libs.decorators.scenario import track_scenario
-from regshape.libs.errors import LayoutError
+from regshape.libs.errors import AuthError, BlobError, LayoutError, ManifestError
 from regshape.libs.layout import (
     generate_config,
     generate_manifest,
     init_layout,
+    push_layout,
     read_index,
     read_stage,
     stage_layer,
@@ -37,6 +38,9 @@ from regshape.libs.layout import (
     update_manifest_annotations,
     validate_layout,
 )
+from regshape.libs.refs import parse_image_ref
+from regshape.libs.transport import RegistryClient
+from regshape.libs.transport.client import TransportConfig
 from regshape.libs.models.mediatype import (
     OCI_IMAGE_CONFIG,
     OCI_IMAGE_LAYER_TAR_GZIP,
@@ -706,3 +710,252 @@ def validate(ctx, layout_path):
         sys.exit(1)
 
     click.echo(f"Layout at {layout_path} is valid.")
+
+
+# ===========================================================================
+# layout push
+# ===========================================================================
+
+
+def _short_digest(digest: str) -> str:
+    """Return a truncated digest for display."""
+    if ":" in digest:
+        return digest[:7 + 1 + 12]  # "sha256:" + 12 hex chars
+    return digest[:12]
+
+
+def _format_size(size: int) -> str:
+    """Return a human-friendly byte-size string."""
+    if size < 1024:
+        return f"{size} B"
+    elif size < 1024 * 1024:
+        return f"{size / 1024:.1f} KB"
+    elif size < 1024 * 1024 * 1024:
+        return f"{size / (1024 * 1024):.1f} MB"
+    return f"{size / (1024 * 1024 * 1024):.1f} GB"
+
+
+@layout.command("push")
+@telemetry_options
+@click.option(
+    "--layout", "-l", "layout_path",
+    required=True,
+    type=click.Path(exists=True),
+    metavar="DIR",
+    help="Root directory of a valid, completed OCI Image Layout.",
+)
+@click.option(
+    "--dest", "-d", "dest",
+    required=True,
+    metavar="IMAGE_REF",
+    help="Destination image reference (registry/repo or registry/repo:tag).",
+)
+@click.option(
+    "--force", is_flag=True, default=False,
+    help="Skip blob existence checks and upload all blobs unconditionally.",
+)
+@click.option(
+    "--chunked", is_flag=True, default=False,
+    help="Use chunked (streaming) upload protocol for blobs.",
+)
+@click.option(
+    "--chunk-size", type=int, default=65536, show_default=True,
+    metavar="BYTES",
+    help="Chunk size in bytes (chunked mode only).",
+)
+@click.option(
+    "--dry-run", is_flag=True, default=False,
+    help="Print what would be pushed without making network calls.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output JSON.")
+@click.pass_context
+@track_scenario("layout push")
+def push_cmd(ctx, layout_path, dest, force, chunked, chunk_size, dry_run, as_json):
+    """Push an OCI Image Layout to a remote registry.
+
+    Reads the layout's index.json, uploads all blobs (layers and config),
+    then pushes each manifest to the destination registry.
+    """
+    # --- Parse destination ---
+    try:
+        registry, repo, reference = parse_image_ref(dest)
+    except ValueError as exc:
+        _error(layout_path, str(exc))
+        sys.exit(1)
+
+    tag_override = reference if reference != "latest" or ":" in dest or "@" in dest else None
+
+    # --- Dry-run mode ---
+    if dry_run:
+        _push_dry_run(layout_path, registry, repo, tag_override, as_json)
+        return
+
+    # --- Build client ---
+    insecure = ctx.obj.get("insecure", False) if ctx.obj else False
+    client = RegistryClient(TransportConfig(registry=registry, insecure=insecure))
+
+    # --- Progress helpers ---
+    use_progress = not as_json and sys.stderr.isatty()
+    current_bar = [None]  # mutable wrapper for closure
+
+    def progress_callback(event, **kwargs):
+        digest = kwargs.get("digest", "")
+        size = kwargs.get("size", 0)
+        if event == "blob_start":
+            label = f"  {_short_digest(digest)} ({_format_size(size)})"
+            if use_progress:
+                bar = click.progressbar(
+                    length=size, label=label, file=sys.stderr,
+                    width=36, show_pos=True,
+                )
+                bar.__enter__()
+                current_bar[0] = bar
+                # Immediately complete — we don't have per-byte callback from
+                # the library upload, so show as complete once done.
+            else:
+                click.echo(f"  Uploading {_short_digest(digest)} ({_format_size(size)})...",
+                           err=True)
+        elif event == "blob_done":
+            if use_progress and current_bar[0] is not None:
+                bar = current_bar[0]
+                bar.update(size)
+                bar.__exit__(None, None, None)
+                current_bar[0] = None
+            else:
+                click.echo(f"  Uploaded  {_short_digest(digest)}", err=True)
+        elif event == "blob_skip":
+            click.echo(f"  {_short_digest(digest)} ({_format_size(size)}) exists, skipping",
+                       err=True)
+        elif event == "manifest_done":
+            ref = kwargs.get("reference", "")
+            click.echo(f"  Manifest {_short_digest(digest)} -> {ref}  pushed",
+                       err=True)
+
+    # --- Execute push ---
+    dest_display = f"{registry}/{repo}"
+    if tag_override:
+        dest_display += f":{tag_override}"
+
+    if not as_json:
+        click.echo(f"Pushing layout {layout_path} -> {dest_display}\n", err=True)
+
+    try:
+        result = push_layout(
+            layout_path=layout_path,
+            client=client,
+            repo=repo,
+            tag_override=tag_override,
+            force=force,
+            chunked=chunked,
+            chunk_size=chunk_size,
+            progress_callback=progress_callback,
+        )
+    except LayoutError as exc:
+        _error(layout_path, str(exc))
+        sys.exit(1)
+    except (AuthError, BlobError, ManifestError) as exc:
+        _error(dest_display, str(exc))
+        sys.exit(1)
+
+    # --- Output ---
+    if as_json:
+        output = {
+            "layout_path": str(layout_path),
+            "destination": result.destination,
+            "manifests": [
+                {
+                    "digest": m.digest,
+                    "reference": m.reference,
+                    "media_type": m.media_type,
+                    "blobs": [
+                        {
+                            "digest": b.digest,
+                            "size": b.size,
+                            "media_type": b.media_type,
+                            "action": b.action,
+                        }
+                        for b in m.blobs
+                    ],
+                    "status": m.status,
+                }
+                for m in result.manifests
+            ],
+            "summary": {
+                "manifests_pushed": result.manifests_pushed,
+                "blobs_uploaded": result.blobs_uploaded,
+                "blobs_skipped": result.blobs_skipped,
+                "bytes_uploaded": result.bytes_uploaded,
+            },
+        }
+        click.echo(json.dumps(output, indent=2))
+    else:
+        click.echo(
+            f"\nPush complete: {result.manifests_pushed} manifest(s), "
+            f"{result.blobs_uploaded} blob(s) uploaded, "
+            f"{result.blobs_skipped} blob(s) skipped.",
+            err=True,
+        )
+
+
+def _push_dry_run(layout_path, registry, repo, tag_override, as_json):
+    """Validate layout and print what would be pushed without network calls."""
+    from regshape.libs.models.manifest import ImageManifest as _IM
+    from regshape.libs.models.manifest import parse_manifest as _pm
+
+    try:
+        validate_layout(layout_path)
+        index = read_index(layout_path)
+    except LayoutError as exc:
+        _error(layout_path, str(exc))
+        sys.exit(1)
+
+    if not index.manifests:
+        _error(layout_path, "index.json contains no manifests")
+        sys.exit(1)
+
+    from regshape.libs.layout import read_blob as _rb
+
+    results = []
+    for entry in index.manifests:
+        manifest_bytes = _rb(layout_path, entry.digest)
+        manifest_obj = _pm(manifest_bytes.decode("utf-8"))
+        blobs = []
+        if isinstance(manifest_obj, _IM):
+            for layer in manifest_obj.layers:
+                blobs.append((layer.digest, layer.size, layer.media_type))
+            blobs.append((manifest_obj.config.digest, manifest_obj.config.size,
+                          manifest_obj.config.media_type))
+
+        if tag_override:
+            ref = tag_override
+        elif entry.annotations and "org.opencontainers.image.ref.name" in entry.annotations:
+            ref = entry.annotations["org.opencontainers.image.ref.name"]
+        else:
+            ref = entry.digest
+
+        results.append((entry, ref, blobs))
+
+    if as_json:
+        output = {
+            "dry_run": True,
+            "layout_path": str(layout_path),
+            "destination": f"{registry}/{repo}",
+            "manifests": [
+                {
+                    "digest": entry.digest,
+                    "reference": ref,
+                    "blobs": [
+                        {"digest": d, "size": s, "media_type": mt}
+                        for d, s, mt in blobs
+                    ],
+                }
+                for entry, ref, blobs in results
+            ],
+        }
+        click.echo(json.dumps(output, indent=2))
+    else:
+        click.echo(f"[dry-run] Layout {layout_path} -> {registry}/{repo}\n")
+        for entry, ref, blobs in results:
+            for digest, size, _mt in blobs:
+                click.echo(f"[dry-run] Would upload blob {_short_digest(digest)} ({_format_size(size)})")
+            click.echo(f"[dry-run] Would push manifest {_short_digest(entry.digest)} as '{ref}'")

--- a/src/regshape/cli/layout.py
+++ b/src/regshape/cli/layout.py
@@ -718,6 +718,19 @@ def validate(ctx, layout_path):
 # ===========================================================================
 
 
+def _has_explicit_ref(dest: str) -> bool:
+    """Return True if *dest* contains an explicit tag or digest.
+
+    A digest is indicated by ``@``.  An explicit tag is a ``:`` that
+    appears after the last ``/`` (so registry port colons like
+    ``localhost:5000/repo`` are not mistaken for tags).
+    """
+    if "@" in dest:
+        return True
+    last_slash = dest.rfind("/")
+    return ":" in dest[last_slash + 1:]
+
+
 def _short_digest(digest: str) -> str:
     """Return a truncated digest for display."""
     if ":" in digest:
@@ -784,7 +797,7 @@ def push_cmd(ctx, layout_path, dest, force, chunked, chunk_size, dry_run, as_jso
         _error(layout_path, str(exc))
         sys.exit(1)
 
-    tag_override = reference if reference != "latest" or ":" in dest or "@" in dest else None
+    tag_override = reference if reference != "latest" or _has_explicit_ref(dest) else None
 
     # --- Dry-run mode ---
     if dry_run:

--- a/src/regshape/cli/layout.py
+++ b/src/regshape/cli/layout.py
@@ -721,7 +721,7 @@ def validate(ctx, layout_path):
 def _short_digest(digest: str) -> str:
     """Return a truncated digest for display."""
     if ":" in digest:
-        return digest[:7 + 1 + 12]  # "sha256:" + 12 hex chars
+        return digest[:7 + 12]  # "sha256:" + 12 hex chars
     return digest[:12]
 
 

--- a/src/regshape/libs/auth/credentials.py
+++ b/src/regshape/libs/auth/credentials.py
@@ -205,8 +205,13 @@ def _get_cred_helper(
         docker_config_path: Optional[str] = None,
 ) -> Optional[str]:
     """
-    Return the credential helper name configured for *registry* in the Docker
-    config ``credHelpers`` map, or ``None`` if no helper is configured.
+    Return the credential helper name configured for *registry*.
+
+    Resolution order:
+
+    1. Per-registry ``credHelpers`` entry (e.g. ``"cgr.dev": "cgr"``).
+    2. Global ``credsStore`` default (e.g. ``"credsStore": "desktop"``).
+    3. ``None`` — no helper configured.
 
     :param registry: The registry hostname.
     :type registry: str
@@ -218,7 +223,12 @@ def _get_cred_helper(
     config = dockerconfig.load_config(docker_config_path)
     if not config:
         return None
-    return config.get("credHelpers", {}).get(registry)
+    # Per-registry override takes precedence
+    helper = config.get("credHelpers", {}).get(registry)
+    if helper:
+        return helper
+    # Fall back to the global default credential store
+    return config.get("credsStore") or None
 
 
 def _get_auth_from_config(

--- a/src/regshape/libs/auth/registryauth.py
+++ b/src/regshape/libs/auth/registryauth.py
@@ -33,15 +33,41 @@ def _parse_auth_header(auth_header: str) -> dict:
     :rtype: dict
     """
     scheme = auth_header.split(" ")[0]
-    params = auth_header[len(scheme):].strip()
+    params_str = auth_header[len(scheme):].strip()
 
-    params = params.split(",")
-    params = [param.replace('"', '') for param in params]
-    params = [param.split('=', 1) for param in params]
-    auth_header = dict(params)
-    auth_header['scheme'] = scheme
+    # Split on commas that are outside quoted strings so that values
+    # containing commas (e.g. scope="repository:repo:pull,push") are
+    # kept intact.
+    params = _split_auth_params(params_str)
+    result = {}
+    for param in params:
+        param = param.strip()
+        if '=' not in param:
+            continue
+        key, value = param.split('=', 1)
+        result[key.strip()] = value.strip().strip('"')
+    result['scheme'] = scheme
 
-    return auth_header
+    return result
+
+
+def _split_auth_params(params_str: str) -> list:
+    """Split a WWW-Authenticate parameter string on commas outside quotes."""
+    parts = []
+    current = []
+    in_quotes = False
+    for ch in params_str:
+        if ch == '"':
+            in_quotes = not in_quotes
+            current.append(ch)
+        elif ch == ',' and not in_quotes:
+            parts.append(''.join(current))
+            current = []
+        else:
+            current.append(ch)
+    if current:
+        parts.append(''.join(current))
+    return parts
 
 def _get_basic_auth(username: str, password: str) -> str:
     """
@@ -126,6 +152,13 @@ def _get_auth_token(
         log.error(e)
         raise AuthError("Token request failed", f"Request to {realm} failed: {e}")
 
+    # If the standard GET failed with 401 and we have a password, try an
+    # OAuth2 refresh-token exchange via POST.  This is needed for registries
+    # like ACR where `az acr login` stores a refresh token (JWT) in the
+    # Docker credential store instead of a plain username/password pair.
+    if response.status_code == 401 and password:
+        response = _try_refresh_token_exchange(realm, query_params, password)
+
     # Parse the response
     if response.status_code != 200:
         log.error(f"Token request failed with status {response.status_code}")
@@ -140,6 +173,45 @@ def _get_auth_token(
         raise AuthError("Token response missing token field")
 
     return token
+
+
+def _try_refresh_token_exchange(
+        realm: str,
+        query_params: dict,
+        refresh_token: str,
+) -> requests.Response:
+    """Attempt an OAuth2 ``refresh_token`` grant against *realm*.
+
+    Registries like Azure Container Registry store a refresh token (JWT) in
+    the Docker credential store (via ``az acr login``).  These tokens cannot
+    be exchanged with a standard GET + Basic-Auth request; instead the token
+    endpoint expects a POST with ``grant_type=refresh_token``.
+
+    :param realm: Token endpoint URL from the ``WWW-Authenticate`` header.
+    :param query_params: ``service`` and optional ``scope`` parameters.
+    :param refresh_token: The refresh token (password value from the
+        credential store).
+    :returns: The :class:`requests.Response` from the POST.
+    :raises AuthError: On connection or transport errors.
+    """
+    post_data = {
+        'grant_type': 'refresh_token',
+        'refresh_token': refresh_token,
+    }
+    post_data.update(query_params)
+
+    log.debug("Attempting OAuth2 refresh-token exchange at %s", realm)
+    try:
+        return requests.post(realm, data=post_data)
+    except requests.exceptions.ConnectionError as e:
+        log.error(e)
+        raise AuthError("Token request failed", f"Unable to connect to {realm}")
+    except requests.exceptions.Timeout as e:
+        log.error(e)
+        raise AuthError("Token request failed", f"Connection to {realm} timed out")
+    except requests.exceptions.RequestException as e:
+        log.error(e)
+        raise AuthError("Token request failed", f"Request to {realm} failed: {e}")
 
 def authenticate(
         auth_header: str,
@@ -156,9 +228,10 @@ def authenticate(
     :rtype: str
     """
     auth_header = _parse_auth_header(auth_header)
-    if auth_header['scheme'] == 'Basic':
+    scheme = auth_header['scheme'].lower()
+    if scheme == 'basic':
         return _get_basic_auth(username, password)
-    elif auth_header['scheme'] == 'Bearer':
+    elif scheme == 'bearer':
         return _get_auth_token(auth_header, username, password)
     else:
         log.error(f"Unknown authentication method: {auth_header['scheme']}")

--- a/src/regshape/libs/blobs/operations.py
+++ b/src/regshape/libs/blobs/operations.py
@@ -476,15 +476,18 @@ def _raise_for_blob_error(
         raise BlobError(
             f"Blob not found: {registry}/{repo}@{digest}",
             detail or "HTTP 404",
+            status_code=404,
         )
     if response.status_code == 405:
         raise BlobError(
             "Operation not supported by this registry",
             detail or "HTTP 405",
+            status_code=405,
         )
     raise BlobError(
         f"Registry error for {registry}/{repo}",
         detail or f"HTTP {response.status_code}",
+        status_code=response.status_code,
     )
 
 

--- a/src/regshape/libs/errors.py
+++ b/src/regshape/libs/errors.py
@@ -46,7 +46,11 @@ class BlobError(RegShapeError):
     """
     Error caused by a malformed, missing, or unprocessable blob or upload session.
     """
-    pass
+
+    def __init__(self, message: str = None, cause: str = None, *args: object,
+                 status_code: int = None) -> None:
+        super().__init__(message, cause, *args)
+        self.status_code = status_code
 
 
 class CatalogError(RegShapeError):

--- a/src/regshape/libs/layout/__init__.py
+++ b/src/regshape/libs/layout/__init__.py
@@ -18,6 +18,7 @@ from regshape.libs.layout.operations import (
     generate_config,
     generate_manifest,
     init_layout,
+    push_layout,
     read_blob,
     read_index,
     read_stage,
@@ -26,6 +27,9 @@ from regshape.libs.layout.operations import (
     update_layer_annotations,
     update_manifest_annotations,
     validate_layout,
+    BlobPushReport,
+    ManifestPushReport,
+    PushResult,
 )
 
 __all__ = [
@@ -47,4 +51,9 @@ __all__ = [
     "read_blob",
     "read_index",
     "validate_layout",
+    # Push
+    "push_layout",
+    "BlobPushReport",
+    "ManifestPushReport",
+    "PushResult",
 ]

--- a/src/regshape/libs/layout/operations.py
+++ b/src/regshape/libs/layout/operations.py
@@ -14,7 +14,6 @@
 """
 
 import hashlib
-import io
 import json
 import os
 import tempfile
@@ -973,14 +972,16 @@ def push_layout(
                                   size=blob_desc.size,
                                   media_type=blob_desc.media_type)
 
-            blob_data = read_blob(layout, blob_desc.digest)
             if chunked:
-                upload_blob_chunked(
-                    client, repo, io.BytesIO(blob_data),
-                    blob_desc.digest,
-                    chunk_size=chunk_size,
-                )
+                blob_file_path = _blob_path(layout, blob_desc.digest)
+                with open(blob_file_path, "rb") as blob_fh:
+                    upload_blob_chunked(
+                        client, repo, blob_fh,
+                        blob_desc.digest,
+                        chunk_size=chunk_size,
+                    )
             else:
+                blob_data = read_blob(layout, blob_desc.digest)
                 upload_blob(client, repo, blob_data, blob_desc.digest)
 
             uploaded_digests.add(blob_desc.digest)

--- a/src/regshape/libs/layout/operations.py
+++ b/src/regshape/libs/layout/operations.py
@@ -14,13 +14,16 @@
 """
 
 import hashlib
+import io
 import json
 import os
 import tempfile
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Union
 
-from regshape.libs.errors import LayoutError
+from regshape.libs.decorators.scenario import track_scenario
+from regshape.libs.errors import BlobError, LayoutError
 from regshape.libs.models.descriptor import Descriptor
 from regshape.libs.models.manifest import ImageIndex, ImageManifest, parse_manifest
 from regshape.libs.models.mediatype import OCI_IMAGE_INDEX
@@ -791,3 +794,224 @@ def update_manifest_annotations(
         digest=new_digest,
         size=new_size,
     )
+
+
+# ===========================================================================
+# Push operations
+# ===========================================================================
+
+
+@dataclass
+class BlobPushReport:
+    """Report for a single blob push action."""
+
+    digest: str
+    size: int
+    media_type: str
+    action: str  # "uploaded", "skipped"
+
+
+@dataclass
+class ManifestPushReport:
+    """Report for pushing a single manifest and its blobs."""
+
+    digest: str
+    reference: str
+    media_type: str
+    blobs: list[BlobPushReport] = field(default_factory=list)
+    status: str = "pushed"
+
+
+@dataclass
+class PushResult:
+    """Aggregated result of a layout push operation."""
+
+    layout_path: str
+    destination: str
+    manifests: list[ManifestPushReport] = field(default_factory=list)
+    manifests_pushed: int = 0
+    blobs_uploaded: int = 0
+    blobs_skipped: int = 0
+    bytes_uploaded: int = 0
+
+
+def _collect_blob_descriptors(manifest: ImageManifest) -> list[Descriptor]:
+    """Return all blob descriptors (layers + config) from a manifest."""
+    blobs: list[Descriptor] = []
+    blobs.extend(manifest.layers)
+    blobs.append(manifest.config)
+    return blobs
+
+
+@track_scenario("layout push")
+def push_layout(
+    layout_path: Union[str, Path],
+    client,
+    repo: str,
+    tag_override: Union[str, None] = None,
+    force: bool = False,
+    chunked: bool = False,
+    chunk_size: int = 65536,
+    progress_callback=None,
+) -> PushResult:
+    """Push an OCI Image Layout to a remote registry.
+
+    Reads the layout's ``index.json`` to discover all manifests and their
+    referenced blobs (layers and configs), uploads every blob, then pushes
+    each manifest.
+
+    :param layout_path: Root of a valid, completed OCI Image Layout.
+    :param client: An authenticated
+        :class:`~regshape.libs.transport.RegistryClient`.
+    :param repo: Target repository name (e.g. ``"myrepo/myimage"``).
+    :param tag_override: If provided, overrides ``ref.name`` annotation
+        for single-manifest layouts. Must be ``None`` when the layout
+        contains multiple manifests.
+    :param force: If ``True``, skip ``HEAD`` existence checks and upload
+        all blobs unconditionally.
+    :param chunked: If ``True``, use the chunked upload protocol.
+    :param chunk_size: Chunk size in bytes (used when *chunked* is ``True``).
+    :param progress_callback: Optional callable invoked as
+        ``progress_callback(event, **kwargs)`` for UI feedback.  Events:
+        ``"blob_start"``, ``"blob_skip"``, ``"blob_done"``,
+        ``"manifest_done"``.
+    :returns: A :class:`PushResult` with per-manifest reports and summary
+        statistics.
+    :raises LayoutError: If the layout is invalid or incomplete.
+    :raises regshape.libs.errors.AuthError: On authentication failure.
+    :raises regshape.libs.errors.BlobError: On blob upload failure.
+    :raises regshape.libs.errors.ManifestError: On manifest push failure.
+    """
+    from regshape.libs.blobs import head_blob, upload_blob, upload_blob_chunked
+    from regshape.libs.manifests import push_manifest
+
+    layout = _lp(layout_path)
+    validate_layout(layout)
+
+    index = _read_index(layout)
+    if not index.manifests:
+        raise LayoutError(
+            "index.json contains no manifests",
+            "run 'layout generate manifest' first",
+        )
+
+    if tag_override and len(index.manifests) > 1:
+        raise LayoutError(
+            f"tag override supplied but index.json has {len(index.manifests)} manifests",
+            "omit the tag or push a single-manifest layout",
+        )
+
+    result = PushResult(
+        layout_path=str(layout),
+        destination=f"{client.config.registry}/{repo}",
+    )
+
+    # Track blobs already uploaded in this session to avoid duplicate work
+    uploaded_digests: set[str] = set()
+
+    for entry_idx, entry in enumerate(index.manifests):
+        manifest_bytes = read_blob(layout, entry.digest)
+        manifest_obj = parse_manifest(manifest_bytes.decode("utf-8"))
+        if not isinstance(manifest_obj, ImageManifest):
+            raise LayoutError(
+                f"manifest {entry.digest} is not an OCI Image Manifest",
+                f"got {type(manifest_obj).__name__}",
+            )
+
+        blob_descs = _collect_blob_descriptors(manifest_obj)
+        manifest_report = ManifestPushReport(
+            digest=entry.digest,
+            reference="",
+            media_type=entry.media_type,
+        )
+
+        # -- Upload blobs --
+        for blob_desc in blob_descs:
+            if blob_desc.digest in uploaded_digests:
+                blob_report = BlobPushReport(
+                    digest=blob_desc.digest,
+                    size=blob_desc.size,
+                    media_type=blob_desc.media_type,
+                    action="skipped",
+                )
+                manifest_report.blobs.append(blob_report)
+                result.blobs_skipped += 1
+                if progress_callback:
+                    progress_callback("blob_skip", digest=blob_desc.digest,
+                                      size=blob_desc.size)
+                continue
+
+            # Check existence unless --force
+            exists = False
+            if not force:
+                try:
+                    head_blob(client, repo, blob_desc.digest)
+                    exists = True
+                except BlobError:
+                    exists = False
+
+            if exists:
+                uploaded_digests.add(blob_desc.digest)
+                blob_report = BlobPushReport(
+                    digest=blob_desc.digest,
+                    size=blob_desc.size,
+                    media_type=blob_desc.media_type,
+                    action="skipped",
+                )
+                manifest_report.blobs.append(blob_report)
+                result.blobs_skipped += 1
+                if progress_callback:
+                    progress_callback("blob_skip", digest=blob_desc.digest,
+                                      size=blob_desc.size)
+                continue
+
+            # Upload
+            if progress_callback:
+                progress_callback("blob_start", digest=blob_desc.digest,
+                                  size=blob_desc.size,
+                                  media_type=blob_desc.media_type)
+
+            blob_data = read_blob(layout, blob_desc.digest)
+            if chunked:
+                upload_blob_chunked(
+                    client, repo, io.BytesIO(blob_data),
+                    blob_desc.digest,
+                    chunk_size=chunk_size,
+                )
+            else:
+                upload_blob(client, repo, blob_data, blob_desc.digest)
+
+            uploaded_digests.add(blob_desc.digest)
+            blob_report = BlobPushReport(
+                digest=blob_desc.digest,
+                size=blob_desc.size,
+                media_type=blob_desc.media_type,
+                action="uploaded",
+            )
+            manifest_report.blobs.append(blob_report)
+            result.blobs_uploaded += 1
+            result.bytes_uploaded += blob_desc.size
+            if progress_callback:
+                progress_callback("blob_done", digest=blob_desc.digest,
+                                  size=blob_desc.size)
+
+        # -- Determine reference --
+        if tag_override:
+            reference = tag_override
+        elif entry.annotations and "org.opencontainers.image.ref.name" in entry.annotations:
+            reference = entry.annotations["org.opencontainers.image.ref.name"]
+        else:
+            reference = entry.digest
+
+        manifest_report.reference = reference
+
+        # -- Push manifest --
+        push_manifest(client, repo, reference, manifest_bytes, entry.media_type)
+        manifest_report.status = "pushed"
+        result.manifests.append(manifest_report)
+        result.manifests_pushed += 1
+        if progress_callback:
+            progress_callback("manifest_done", digest=entry.digest,
+                              reference=reference)
+
+    return result

--- a/src/regshape/libs/layout/operations.py
+++ b/src/regshape/libs/layout/operations.py
@@ -947,7 +947,9 @@ def push_layout(
                 try:
                     head_blob(client, repo, blob_desc.digest)
                     exists = True
-                except BlobError:
+                except BlobError as exc:
+                    if exc.status_code is not None and exc.status_code != 404:
+                        raise
                     exists = False
 
             if exists:

--- a/src/regshape/libs/transport/models.py
+++ b/src/regshape/libs/transport/models.py
@@ -70,12 +70,13 @@ class RegistryResponse:
     :attr:`raw_response` directly.
     
     :param status_code: HTTP status code
-    :param headers: Response headers as key-value dict  
+    :param headers: Response headers as a mapping (e.g. dict or
+        ``CaseInsensitiveDict``)
     :param body: Response body as bytes, or ``None`` for streaming responses
     :param raw_response: Original requests.Response for streaming access
     """
     status_code: int
-    headers: Dict[str, str]
+    headers: Mapping[str, str]
     body: Optional[bytes]
     raw_response: requests.Response
 
@@ -84,7 +85,7 @@ class RegistryResponse:
         if not isinstance(self.status_code, int):
             raise TypeError("RegistryResponse.status_code must be an int")
         if not isinstance(self.headers, Mapping):
-            raise TypeError("RegistryResponse.headers must be a dict")
+            raise TypeError("RegistryResponse.headers must be a mapping")
         if self.body is not None and not isinstance(self.body, bytes):
             raise TypeError("RegistryResponse.body must be bytes or None")
 

--- a/src/regshape/libs/transport/models.py
+++ b/src/regshape/libs/transport/models.py
@@ -15,6 +15,7 @@
 
 from dataclasses import dataclass
 from typing import Optional, Union, Iterable, Dict, Any
+from collections.abc import Mapping
 
 import requests
 
@@ -82,7 +83,7 @@ class RegistryResponse:
         """Validate response fields."""
         if not isinstance(self.status_code, int):
             raise TypeError("RegistryResponse.status_code must be an int")
-        if not isinstance(self.headers, dict):
+        if not isinstance(self.headers, Mapping):
             raise TypeError("RegistryResponse.headers must be a dict")
         if self.body is not None and not isinstance(self.body, bytes):
             raise TypeError("RegistryResponse.body must be bytes or None")
@@ -109,9 +110,12 @@ class RegistryResponse:
             to preserve streaming.  Defaults to ``False``.
         :returns: A :class:`RegistryResponse` instance.
         """
+        # Preserve the CaseInsensitiveDict from requests.Response so
+        # that header lookups in middleware are case-insensitive per
+        # HTTP spec (RFC 7230 §3.2).
         return cls(
             status_code=response.status_code,
-            headers=dict(response.headers),
+            headers=response.headers,
             body=None if stream else response.content,
             raw_response=response,
         )

--- a/src/regshape/tests/test_auth.py
+++ b/src/regshape/tests/test_auth.py
@@ -102,6 +102,18 @@ class TestParseAuthHeader:
         assert result['realm'] == 'https://auth.example.com/token?service=reg'
         assert result['service'] == 'registry.example.com'
 
+    def test_scope_with_comma_in_value(self):
+        """Commas inside quoted scope values (pull,push) must be preserved."""
+        header = (
+            'Bearer realm="https://auth.example.com/token",'
+            'service="registry.example.com",'
+            'scope="repository:test/myartifact:pull,push"'
+        )
+        result = registryauth._parse_auth_header(header)
+        assert result['scope'] == 'repository:test/myartifact:pull,push'
+        assert result['service'] == 'registry.example.com'
+        assert result['realm'] == 'https://auth.example.com/token'
+
 
 # ===========================================================================
 # registryauth._get_basic_auth
@@ -196,10 +208,37 @@ class TestGetAuthToken:
 
     def test_raises_auth_error_on_non_200_status(self):
         header = self._header()
-        with patch('regshape.libs.auth.registryauth.requests.get') as mock_get:
+        with patch('regshape.libs.auth.registryauth.requests.get') as mock_get, \
+             patch('regshape.libs.auth.registryauth.requests.post') as mock_post:
             mock_get.return_value = MagicMock(status_code=401, text='{"errors":[]}')
+            mock_post.return_value = MagicMock(status_code=401, text='{"errors":[]}')
             with pytest.raises(AuthError):
                 registryauth._get_auth_token(header, 'user', 'wrongpass')
+
+    def test_falls_back_to_refresh_token_post_on_401(self):
+        """When GET returns 401, tries POST with grant_type=refresh_token."""
+        header = self._header(scope='repository:myrepo:pull')
+        with patch('regshape.libs.auth.registryauth.requests.get') as mock_get, \
+             patch('regshape.libs.auth.registryauth.requests.post') as mock_post:
+            mock_get.return_value = MagicMock(status_code=401, text='{}')
+            mock_post.return_value = _token_response('refreshed-tok')
+            token = registryauth._get_auth_token(header, '<token>', 'eyJhbGci...')
+        assert token == 'refreshed-tok'
+        post_data = mock_post.call_args[1]['data']
+        assert post_data['grant_type'] == 'refresh_token'
+        assert post_data['refresh_token'] == 'eyJhbGci...'
+        assert post_data['service'] == 'registry.example.com'
+        assert post_data['scope'] == 'repository:myrepo:pull'
+
+    def test_no_refresh_fallback_without_credentials(self):
+        """When GET returns 401 with no password, no POST is attempted."""
+        header = self._header()
+        with patch('regshape.libs.auth.registryauth.requests.get') as mock_get, \
+             patch('regshape.libs.auth.registryauth.requests.post') as mock_post:
+            mock_get.return_value = MagicMock(status_code=401, text='{}')
+            with pytest.raises(AuthError):
+                registryauth._get_auth_token(header)
+        mock_post.assert_not_called()
 
     def test_raises_auth_error_on_connection_error(self):
         header = self._header()
@@ -247,6 +286,23 @@ class TestAuthenticate:
         header = 'Digest realm="example.com",nonce="abc123"'
         with pytest.raises(AuthError):
             registryauth.authenticate(header)
+
+    def test_bearer_scheme_case_insensitive(self):
+        """Scheme comparison is case-insensitive per RFC 7235."""
+        for scheme in ('bearer', 'BEARER', 'Bearer', 'bEaReR'):
+            header = f'{scheme} realm="https://auth.example.com/token",service="registry.example.com"'
+            with patch('regshape.libs.auth.registryauth.requests.get') as mock_get:
+                mock_get.return_value = _token_response('tok')
+                result = registryauth.authenticate(header, 'u', 'p')
+            assert result == 'tok', f"Failed for scheme: {scheme}"
+
+    def test_basic_scheme_case_insensitive(self):
+        """Basic scheme comparison is case-insensitive per RFC 7235."""
+        for scheme in ('basic', 'BASIC', 'Basic'):
+            header = f'{scheme} realm="https://registry.example.com"'
+            result = registryauth.authenticate(header, 'alice', 'secret')
+            expected = base64.b64encode(b'alice:secret').decode('utf-8')
+            assert result == expected, f"Failed for scheme: {scheme}"
 
 
 # ===========================================================================

--- a/src/regshape/tests/test_auth_cli.py
+++ b/src/regshape/tests/test_auth_cli.py
@@ -206,6 +206,27 @@ class TestGetCredHelper:
                    return_value=None):
             assert _get_cred_helper(REGISTRY) is None
 
+    def test_falls_back_to_credsStore(self):
+        """When credHelpers has no entry, credsStore is used as fallback."""
+        config = {"credsStore": "desktop", "credHelpers": {"other.io": "ecr-login"}}
+        with patch("regshape.libs.auth.credentials.dockerconfig.load_config",
+                   return_value=config):
+            assert _get_cred_helper(REGISTRY) == "desktop"
+
+    def test_credHelpers_takes_priority_over_credsStore(self):
+        """Per-registry credHelpers entry wins over global credsStore."""
+        config = {"credsStore": "desktop", "credHelpers": {REGISTRY: "ecr-login"}}
+        with patch("regshape.libs.auth.credentials.dockerconfig.load_config",
+                   return_value=config):
+            assert _get_cred_helper(REGISTRY) == "ecr-login"
+
+    def test_credsStore_empty_string_returns_none(self):
+        """An empty credsStore value should be treated as absent."""
+        config = {"credsStore": ""}
+        with patch("regshape.libs.auth.credentials.dockerconfig.load_config",
+                   return_value=config):
+            assert _get_cred_helper(REGISTRY) is None
+
 
 # ===========================================================================
 # TestStoreCredentials

--- a/src/regshape/tests/test_auth_cli.py
+++ b/src/regshape/tests/test_auth_cli.py
@@ -67,6 +67,7 @@ def _make_response(status_code: int, www_auth: str = None, text: str = "{}") -> 
     resp = MagicMock(spec=requests.Response)
     resp.status_code = status_code
     resp.text = text
+    resp.content = text.encode("utf-8")
     headers = {}
     if www_auth:
         headers["WWW-Authenticate"] = www_auth

--- a/src/regshape/tests/test_layout_cli.py
+++ b/src/regshape/tests/test_layout_cli.py
@@ -55,14 +55,14 @@ def _full_pipeline(layout_dir):
 class TestLayoutInitCLI:
     def test_init_creates_layout(self, tmp_path):
         output = str(tmp_path / "layout")
-        result = _runner().invoke(regshape, ["layout", "init", "--output", output])
+        result = _runner().invoke(regshape, ["layout", "init", "--path", output])
         assert result.exit_code == 0, result.output
         assert "Initialised" in result.output
 
     def test_init_json_output(self, tmp_path):
         output = str(tmp_path / "layout")
         result = _runner().invoke(
-            regshape, ["layout", "init", "--output", output, "--json"]
+            regshape, ["layout", "init", "--path", output, "--json"]
         )
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
@@ -71,7 +71,7 @@ class TestLayoutInitCLI:
     def test_init_fails_if_already_exists(self, tmp_path):
         output = str(tmp_path / "layout")
         init_layout(tmp_path / "layout")
-        result = _runner().invoke(regshape, ["layout", "init", "--output", output])
+        result = _runner().invoke(regshape, ["layout", "init", "--path", output])
         assert result.exit_code != 0
 
 
@@ -89,7 +89,7 @@ class TestLayoutAddLayerCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "add", "layer",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--file", str(layer_file),
             "--media-type", OCI_IMAGE_LAYER_TAR_GZIP,
         ])
@@ -104,7 +104,7 @@ class TestLayoutAddLayerCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "add", "layer",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--file", str(layer_file),
             "--media-type", OCI_IMAGE_LAYER_TAR_GZIP,
             "--json",
@@ -123,7 +123,7 @@ class TestLayoutAddLayerCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "add", "layer",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--file", str(layer_file),
             "--media-type", OCI_IMAGE_LAYER_TAR_GZIP,
             "--annotation", "com.example.role=base",
@@ -142,7 +142,7 @@ class TestLayoutAddLayerCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "add", "layer",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--file", str(layer_file),
             "--media-type", OCI_IMAGE_LAYER_TAR_GZIP,
         ])
@@ -154,7 +154,7 @@ class TestLayoutAddLayerCLI:
         layer_file.write_bytes(_make_gzip(b"content"))
         result = _runner().invoke(regshape, [
             "layout", "add", "layer",
-            "--layout", str(tmp_path / "nolayout"),
+            "--path", str(tmp_path / "nolayout"),
             "--file", str(layer_file),
             "--media-type", OCI_IMAGE_LAYER_TAR_GZIP,
         ])
@@ -178,7 +178,7 @@ class TestLayoutAnnotateLayerCLI:
         layout_dir = self._setup(tmp_path)
         result = _runner().invoke(regshape, [
             "layout", "annotate", "layer",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--index", "0",
             "--annotation", "org.opencontainers.image.created=2026-03-08",
         ])
@@ -189,7 +189,7 @@ class TestLayoutAnnotateLayerCLI:
         layout_dir = self._setup(tmp_path)
         result = _runner().invoke(regshape, [
             "layout", "annotate", "layer",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--index", "0",
             "--annotation", "k=v",
             "--json",
@@ -203,7 +203,7 @@ class TestLayoutAnnotateLayerCLI:
         layout_dir = self._setup(tmp_path)
         result = _runner().invoke(regshape, [
             "layout", "annotate", "layer",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--index", "99",
             "--annotation", "k=v",
         ])
@@ -226,7 +226,7 @@ class TestLayoutAnnotateManifestCLI:
         layout_dir = self._setup(tmp_path)
         result = _runner().invoke(regshape, [
             "layout", "annotate", "manifest",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--annotation", "org.opencontainers.image.version=1.0.0",
         ])
         assert result.exit_code == 0, result.output
@@ -236,7 +236,7 @@ class TestLayoutAnnotateManifestCLI:
         layout_dir = self._setup(tmp_path)
         result = _runner().invoke(regshape, [
             "layout", "annotate", "manifest",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--annotation", "k=v",
             "--json",
         ])
@@ -249,7 +249,7 @@ class TestLayoutAnnotateManifestCLI:
         init_layout(layout_dir)
         result = _runner().invoke(regshape, [
             "layout", "annotate", "manifest",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--annotation", "k=v",
         ])
         assert result.exit_code != 0
@@ -268,7 +268,7 @@ class TestLayoutGenerateConfigCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "generate", "config",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--architecture", "arm64",
             "--os", "linux",
             "--media-type", "application/vnd.oci.image.config.v1+json",
@@ -283,7 +283,7 @@ class TestLayoutGenerateConfigCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "generate", "config",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--architecture", "amd64",
             "--os", "linux",
             "--media-type", "application/vnd.oci.image.config.v1+json",
@@ -298,7 +298,7 @@ class TestLayoutGenerateConfigCLI:
         init_layout(layout_dir)
         result = _runner().invoke(regshape, [
             "layout", "generate", "config",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--architecture", "amd64",
             "--os", "linux",
             "--media-type", "application/vnd.oci.image.config.v1+json",
@@ -323,7 +323,7 @@ class TestLayoutGenerateManifestCLI:
         layout_dir = self._setup_with_config(tmp_path)
         result = _runner().invoke(regshape, [
             "layout", "generate", "manifest",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--ref-name", "latest",
             "--media-type", "application/vnd.oci.image.manifest.v1+json",
         ])
@@ -334,7 +334,7 @@ class TestLayoutGenerateManifestCLI:
         layout_dir = self._setup_with_config(tmp_path)
         result = _runner().invoke(regshape, [
             "layout", "generate", "manifest",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--ref-name", "v1.0",
             "--media-type", "application/vnd.oci.image.manifest.v1+json",
             "--json",
@@ -350,7 +350,7 @@ class TestLayoutGenerateManifestCLI:
         stage_layer(layout_dir, _make_gzip(b"layer"), OCI_IMAGE_LAYER_TAR_GZIP)
         result = _runner().invoke(regshape, [
             "layout", "generate", "manifest",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--ref-name", "latest",
             "--media-type", "application/vnd.oci.image.manifest.v1+json",
         ])
@@ -374,7 +374,7 @@ class TestLayoutUpdateConfigCLI:
         layout_dir = self._setup(tmp_path)
         result = _runner().invoke(regshape, [
             "layout", "update", "config",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--architecture", "arm64",
         ])
         assert result.exit_code == 0, result.output
@@ -384,7 +384,7 @@ class TestLayoutUpdateConfigCLI:
         layout_dir = self._setup(tmp_path)
         result = _runner().invoke(regshape, [
             "layout", "update", "config",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--architecture", "arm64",
             "--json",
         ])
@@ -398,7 +398,7 @@ class TestLayoutUpdateConfigCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "update", "config",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--architecture", "arm64",
             "--json",
         ])
@@ -412,7 +412,7 @@ class TestLayoutUpdateConfigCLI:
         stage_layer(layout_dir, _make_gzip(b"l"), OCI_IMAGE_LAYER_TAR_GZIP)
         result = _runner().invoke(regshape, [
             "layout", "update", "config",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--architecture", "arm64",
         ])
         assert result.exit_code != 0
@@ -429,7 +429,7 @@ class TestLayoutStatusCLI:
         init_layout(layout_dir)
         result = _runner().invoke(regshape, [
             "layout", "status",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
         ])
         assert result.exit_code == 0, result.output
         assert "Layers staged: 0" in result.output
@@ -439,7 +439,7 @@ class TestLayoutStatusCLI:
         init_layout(layout_dir)
         result = _runner().invoke(regshape, [
             "layout", "status",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--json",
         ])
         assert result.exit_code == 0, result.output
@@ -453,7 +453,7 @@ class TestLayoutStatusCLI:
         stage_layer(layout_dir, _make_gzip(b"layer"), OCI_IMAGE_LAYER_TAR_GZIP)
         result = _runner().invoke(regshape, [
             "layout", "status",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
         ])
         assert result.exit_code == 0, result.output
         assert "Layers staged: 1" in result.output
@@ -470,7 +470,7 @@ class TestLayoutShowCLI:
         init_layout(layout_dir)
         result = _runner().invoke(regshape, [
             "layout", "show",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
         ])
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
@@ -489,7 +489,7 @@ class TestLayoutValidateCLI:
         init_layout(layout_dir)
         result = _runner().invoke(regshape, [
             "layout", "validate",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
         ])
         assert result.exit_code == 0, result.output
         assert "valid" in result.output
@@ -500,7 +500,7 @@ class TestLayoutValidateCLI:
         _full_pipeline(layout_dir)
         result = _runner().invoke(regshape, [
             "layout", "validate",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
         ])
         assert result.exit_code == 0, result.output
         assert "valid" in result.output

--- a/src/regshape/tests/test_layout_push.py
+++ b/src/regshape/tests/test_layout_push.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+
+"""Tests for ``layout push`` — both the library function and the CLI command.
+
+Library operations are tested with mocked registry calls (no real network).
+CLI tests use the Click test runner.
+"""
+
+import gzip
+import io
+import json
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from regshape.cli.main import regshape
+from regshape.libs.errors import BlobError, LayoutError
+from regshape.libs.layout.operations import (
+    PushResult,
+    generate_config,
+    generate_manifest,
+    init_layout,
+    push_layout,
+    stage_layer,
+    validate_layout,
+)
+from regshape.libs.models.mediatype import OCI_IMAGE_LAYER_TAR_GZIP
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _runner():
+    return CliRunner()
+
+
+def _make_gzip(data: bytes) -> bytes:
+    buf = io.BytesIO()
+    with gzip.GzipFile(fileobj=buf, mode="wb", mtime=0) as f:
+        f.write(data)
+    return buf.getvalue()
+
+
+def _build_layout(tmp_path, ref_name="latest"):
+    """Create a complete single-manifest layout for testing."""
+    layout_dir = tmp_path / "layout"
+    init_layout(layout_dir)
+    layer = _make_gzip(b"test layer content")
+    stage_layer(layout_dir, layer, OCI_IMAGE_LAYER_TAR_GZIP)
+    generate_config(layout_dir)
+    generate_manifest(layout_dir, ref_name=ref_name)
+    return layout_dir
+
+
+def _mock_client(registry="registry.io"):
+    """Return a mock RegistryClient."""
+    client = MagicMock()
+    client.config = MagicMock()
+    client.config.registry = registry
+    client.config.insecure = False
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Library: push_layout
+# ---------------------------------------------------------------------------
+
+
+class TestPushLayout:
+    """Tests for the push_layout library function."""
+
+    @patch("regshape.libs.manifests.push_manifest")
+    @patch("regshape.libs.blobs.upload_blob")
+    @patch("regshape.libs.blobs.head_blob")
+    def test_push_uploads_all_blobs_and_manifest(
+        self, mock_head, mock_upload, mock_push_manifest, tmp_path
+    ):
+        layout_dir = _build_layout(tmp_path)
+        client = _mock_client()
+
+        # All blobs are new (HEAD returns 404)
+        mock_head.side_effect = BlobError("not found", "404")
+        mock_upload.return_value = "sha256:confirmed"
+        mock_push_manifest.return_value = "sha256:manifest_confirmed"
+
+        result = push_layout(layout_dir, client, "myrepo/myimage",
+                             tag_override="latest")
+
+        assert isinstance(result, PushResult)
+        assert result.manifests_pushed == 1
+        assert result.blobs_uploaded == 2  # 1 layer + 1 config
+        assert result.blobs_skipped == 0
+        assert mock_upload.call_count == 2
+        assert mock_push_manifest.call_count == 1
+
+    @patch("regshape.libs.manifests.push_manifest")
+    @patch("regshape.libs.blobs.upload_blob")
+    @patch("regshape.libs.blobs.head_blob")
+    def test_push_skips_existing_blobs(
+        self, mock_head, mock_upload, mock_push_manifest, tmp_path
+    ):
+        layout_dir = _build_layout(tmp_path)
+        client = _mock_client()
+
+        # All blobs already exist (HEAD returns success)
+        mock_head.return_value = MagicMock()
+        mock_push_manifest.return_value = "sha256:manifest_confirmed"
+
+        result = push_layout(layout_dir, client, "myrepo/myimage",
+                             tag_override="latest")
+
+        assert result.blobs_uploaded == 0
+        assert result.blobs_skipped == 2
+        mock_upload.assert_not_called()
+
+    @patch("regshape.libs.manifests.push_manifest")
+    @patch("regshape.libs.blobs.upload_blob")
+    @patch("regshape.libs.blobs.head_blob")
+    def test_push_force_skips_head_check(
+        self, mock_head, mock_upload, mock_push_manifest, tmp_path
+    ):
+        layout_dir = _build_layout(tmp_path)
+        client = _mock_client()
+
+        mock_upload.return_value = "sha256:confirmed"
+        mock_push_manifest.return_value = "sha256:manifest_confirmed"
+
+        result = push_layout(layout_dir, client, "myrepo/myimage",
+                             tag_override="latest", force=True)
+
+        mock_head.assert_not_called()
+        assert result.blobs_uploaded == 2
+
+    @patch("regshape.libs.manifests.push_manifest")
+    @patch("regshape.libs.blobs.upload_blob_chunked")
+    @patch("regshape.libs.blobs.head_blob")
+    def test_push_chunked_mode(
+        self, mock_head, mock_upload_chunked, mock_push_manifest, tmp_path
+    ):
+        layout_dir = _build_layout(tmp_path)
+        client = _mock_client()
+
+        mock_head.side_effect = BlobError("not found", "404")
+        mock_upload_chunked.return_value = "sha256:confirmed"
+        mock_push_manifest.return_value = "sha256:manifest_confirmed"
+
+        result = push_layout(layout_dir, client, "myrepo/myimage",
+                             tag_override="latest", chunked=True,
+                             chunk_size=1024)
+
+        assert mock_upload_chunked.call_count == 2
+        assert result.blobs_uploaded == 2
+
+    @patch("regshape.libs.manifests.push_manifest")
+    @patch("regshape.libs.blobs.upload_blob")
+    @patch("regshape.libs.blobs.head_blob")
+    def test_push_uses_ref_name_annotation(
+        self, mock_head, mock_upload, mock_push_manifest, tmp_path
+    ):
+        layout_dir = _build_layout(tmp_path, ref_name="v1.0")
+        client = _mock_client()
+
+        mock_head.side_effect = BlobError("not found", "404")
+        mock_upload.return_value = "sha256:confirmed"
+        mock_push_manifest.return_value = "sha256:manifest_confirmed"
+
+        result = push_layout(layout_dir, client, "myrepo/myimage")
+
+        assert result.manifests[0].reference == "v1.0"
+        # Verify the manifest was pushed with "v1.0" as reference
+        call_args = mock_push_manifest.call_args
+        assert call_args[0][2] == "v1.0"
+
+    @patch("regshape.libs.manifests.push_manifest")
+    @patch("regshape.libs.blobs.upload_blob")
+    @patch("regshape.libs.blobs.head_blob")
+    def test_push_tag_override_wins(
+        self, mock_head, mock_upload, mock_push_manifest, tmp_path
+    ):
+        layout_dir = _build_layout(tmp_path, ref_name="v1.0")
+        client = _mock_client()
+
+        mock_head.side_effect = BlobError("not found", "404")
+        mock_upload.return_value = "sha256:confirmed"
+        mock_push_manifest.return_value = "sha256:manifest_confirmed"
+
+        result = push_layout(layout_dir, client, "myrepo/myimage",
+                             tag_override="prod")
+
+        assert result.manifests[0].reference == "prod"
+        call_args = mock_push_manifest.call_args
+        assert call_args[0][2] == "prod"
+
+    def test_push_fails_on_invalid_layout(self, tmp_path):
+        layout_dir = tmp_path / "bad"
+        layout_dir.mkdir()
+        client = _mock_client()
+
+        with pytest.raises(LayoutError):
+            push_layout(layout_dir, client, "myrepo/myimage")
+
+    def test_push_fails_on_empty_index(self, tmp_path):
+        layout_dir = tmp_path / "layout"
+        init_layout(layout_dir)
+        client = _mock_client()
+
+        with pytest.raises(LayoutError, match="no manifests"):
+            push_layout(layout_dir, client, "myrepo/myimage")
+
+    def test_push_fails_tag_override_with_multi_manifest(self, tmp_path):
+        """Tag override with multiple manifests should fail."""
+        layout_dir = tmp_path / "layout"
+        init_layout(layout_dir)
+        layer = _make_gzip(b"layer1")
+        stage_layer(layout_dir, layer, OCI_IMAGE_LAYER_TAR_GZIP)
+        generate_config(layout_dir)
+        generate_manifest(layout_dir, ref_name="first")
+        # Reset staging to add a second manifest
+        from regshape.libs.layout.operations import _read_stage_raw, _write_stage
+        stage = _read_stage_raw(layout_dir)
+        stage["layers"] = []
+        stage["config"] = None
+        stage["manifest"] = None
+        _write_stage(layout_dir, stage)
+        layer2 = _make_gzip(b"layer2")
+        stage_layer(layout_dir, layer2, OCI_IMAGE_LAYER_TAR_GZIP)
+        generate_config(layout_dir, architecture="arm64")
+        generate_manifest(layout_dir, ref_name="second")
+
+        client = _mock_client()
+        with pytest.raises(LayoutError, match="tag override"):
+            push_layout(layout_dir, client, "myrepo/myimage",
+                        tag_override="latest")
+
+    @patch("regshape.libs.manifests.push_manifest")
+    @patch("regshape.libs.blobs.upload_blob")
+    @patch("regshape.libs.blobs.head_blob")
+    def test_push_progress_callback_receives_events(
+        self, mock_head, mock_upload, mock_push_manifest, tmp_path
+    ):
+        layout_dir = _build_layout(tmp_path)
+        client = _mock_client()
+
+        mock_head.side_effect = BlobError("not found", "404")
+        mock_upload.return_value = "sha256:confirmed"
+        mock_push_manifest.return_value = "sha256:manifest_confirmed"
+
+        events = []
+
+        def cb(event, **kwargs):
+            events.append(event)
+
+        push_layout(layout_dir, client, "myrepo/myimage",
+                    tag_override="latest", progress_callback=cb)
+
+        assert "blob_start" in events
+        assert "blob_done" in events
+        assert "manifest_done" in events
+
+    @patch("regshape.libs.manifests.push_manifest")
+    @patch("regshape.libs.blobs.upload_blob")
+    @patch("regshape.libs.blobs.head_blob")
+    def test_push_result_has_correct_summary(
+        self, mock_head, mock_upload, mock_push_manifest, tmp_path
+    ):
+        layout_dir = _build_layout(tmp_path)
+        client = _mock_client()
+
+        # First blob exists, second is new
+        call_count = [0]
+        def head_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise BlobError("not found", "404")
+            return MagicMock()
+
+        mock_head.side_effect = head_side_effect
+        mock_upload.return_value = "sha256:confirmed"
+        mock_push_manifest.return_value = "sha256:manifest_confirmed"
+
+        result = push_layout(layout_dir, client, "myrepo/myimage",
+                             tag_override="latest")
+
+        assert result.blobs_uploaded == 1
+        assert result.blobs_skipped == 1
+        assert result.manifests_pushed == 1
+        assert result.bytes_uploaded > 0
+
+
+# ---------------------------------------------------------------------------
+# CLI: layout push
+# ---------------------------------------------------------------------------
+
+
+class TestPushCLI:
+    """Tests for the layout push CLI command."""
+
+    @patch("regshape.cli.layout.RegistryClient")
+    @patch("regshape.cli.layout.push_layout")
+    def test_push_basic(self, mock_push, mock_client_cls, tmp_path):
+        layout_dir = _build_layout(tmp_path)
+        mock_push.return_value = PushResult(
+            layout_path=str(layout_dir),
+            destination="registry.io/myrepo",
+            manifests_pushed=1,
+            blobs_uploaded=2,
+            blobs_skipped=0,
+            bytes_uploaded=1024,
+        )
+
+        result = _runner().invoke(regshape, [
+            "layout", "push",
+            "--layout", str(layout_dir),
+            "--dest", "registry.io/myrepo:latest",
+        ])
+        assert result.exit_code == 0, result.output
+        assert "Push complete" in result.stderr
+
+    @patch("regshape.cli.layout.RegistryClient")
+    @patch("regshape.cli.layout.push_layout")
+    def test_push_json_output(self, mock_push, mock_client_cls, tmp_path):
+        layout_dir = _build_layout(tmp_path)
+        from regshape.libs.layout.operations import BlobPushReport, ManifestPushReport
+        mock_push.return_value = PushResult(
+            layout_path=str(layout_dir),
+            destination="registry.io/myrepo",
+            manifests=[ManifestPushReport(
+                digest="sha256:aaa",
+                reference="latest",
+                media_type="application/vnd.oci.image.manifest.v1+json",
+                blobs=[BlobPushReport(
+                    digest="sha256:bbb",
+                    size=100,
+                    media_type="application/vnd.oci.image.layer.v1.tar+gzip",
+                    action="uploaded",
+                )],
+                status="pushed",
+            )],
+            manifests_pushed=1,
+            blobs_uploaded=1,
+            blobs_skipped=0,
+            bytes_uploaded=100,
+        )
+
+        result = _runner().invoke(regshape, [
+            "layout", "push",
+            "--layout", str(layout_dir),
+            "--dest", "registry.io/myrepo:latest",
+            "--json",
+        ])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["summary"]["manifests_pushed"] == 1
+        assert data["manifests"][0]["status"] == "pushed"
+
+    def test_push_dry_run(self, tmp_path):
+        layout_dir = _build_layout(tmp_path)
+
+        result = _runner().invoke(regshape, [
+            "layout", "push",
+            "--layout", str(layout_dir),
+            "--dest", "registry.io/myrepo:latest",
+            "--dry-run",
+        ])
+        assert result.exit_code == 0, result.output
+        assert "[dry-run]" in result.output
+        assert "Would upload blob" in result.output
+        assert "Would push manifest" in result.output
+
+    def test_push_dry_run_json(self, tmp_path):
+        layout_dir = _build_layout(tmp_path)
+
+        result = _runner().invoke(regshape, [
+            "layout", "push",
+            "--layout", str(layout_dir),
+            "--dest", "registry.io/myrepo:latest",
+            "--dry-run",
+            "--json",
+        ])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["dry_run"] is True
+        assert len(data["manifests"]) == 1
+        assert len(data["manifests"][0]["blobs"]) >= 1
+
+    def test_push_fails_bad_dest(self, tmp_path):
+        layout_dir = _build_layout(tmp_path)
+
+        result = _runner().invoke(regshape, [
+            "layout", "push",
+            "--layout", str(layout_dir),
+            "--dest", "nope",
+        ])
+        assert result.exit_code != 0
+
+    @patch("regshape.cli.layout.RegistryClient")
+    @patch("regshape.cli.layout.push_layout")
+    def test_push_layout_error_exits_1(self, mock_push, mock_client_cls, tmp_path):
+        layout_dir = _build_layout(tmp_path)
+        mock_push.side_effect = LayoutError("invalid", "test")
+
+        result = _runner().invoke(regshape, [
+            "layout", "push",
+            "--layout", str(layout_dir),
+            "--dest", "registry.io/myrepo:latest",
+        ])
+        assert result.exit_code == 1
+
+    @patch("regshape.cli.layout.RegistryClient")
+    @patch("regshape.cli.layout.push_layout")
+    def test_push_with_force_flag(self, mock_push, mock_client_cls, tmp_path):
+        layout_dir = _build_layout(tmp_path)
+        mock_push.return_value = PushResult(
+            layout_path=str(layout_dir),
+            destination="registry.io/myrepo",
+            manifests_pushed=1,
+            blobs_uploaded=2,
+            blobs_skipped=0,
+            bytes_uploaded=1024,
+        )
+
+        result = _runner().invoke(regshape, [
+            "layout", "push",
+            "--layout", str(layout_dir),
+            "--dest", "registry.io/myrepo:latest",
+            "--force",
+        ])
+        assert result.exit_code == 0, result.output
+        # Verify force=True was passed
+        call_kwargs = mock_push.call_args[1]
+        assert call_kwargs["force"] is True
+
+    @patch("regshape.cli.layout.RegistryClient")
+    @patch("regshape.cli.layout.push_layout")
+    def test_push_with_chunked_flags(self, mock_push, mock_client_cls, tmp_path):
+        layout_dir = _build_layout(tmp_path)
+        mock_push.return_value = PushResult(
+            layout_path=str(layout_dir),
+            destination="registry.io/myrepo",
+            manifests_pushed=1,
+            blobs_uploaded=2,
+            blobs_skipped=0,
+            bytes_uploaded=1024,
+        )
+
+        result = _runner().invoke(regshape, [
+            "layout", "push",
+            "--layout", str(layout_dir),
+            "--dest", "registry.io/myrepo:latest",
+            "--chunked",
+            "--chunk-size", "1048576",
+        ])
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_push.call_args[1]
+        assert call_kwargs["chunked"] is True
+        assert call_kwargs["chunk_size"] == 1048576

--- a/src/regshape/tests/test_layout_push.py
+++ b/src/regshape/tests/test_layout_push.py
@@ -56,6 +56,22 @@ def _build_layout(tmp_path, ref_name="latest"):
     return layout_dir
 
 
+def _build_multi_manifest_layout(tmp_path):
+    """Create a layout with two manifests for testing."""
+    layout_dir = tmp_path / "layout"
+    init_layout(layout_dir)
+    layer = _make_gzip(b"test layer content")
+    stage_layer(layout_dir, layer, OCI_IMAGE_LAYER_TAR_GZIP)
+    generate_config(layout_dir)
+    generate_manifest(layout_dir, ref_name="v1")
+    # Stage a second layer + config + manifest to get two entries in index.json
+    layer2 = _make_gzip(b"second layer content")
+    stage_layer(layout_dir, layer2, OCI_IMAGE_LAYER_TAR_GZIP)
+    generate_config(layout_dir)
+    generate_manifest(layout_dir, ref_name="v2")
+    return layout_dir
+
+
 def _mock_client(registry="registry.io"):
     """Return a mock RegistryClient."""
     client = MagicMock()
@@ -458,3 +474,15 @@ class TestPushCLI:
         call_kwargs = mock_push.call_args[1]
         assert call_kwargs["chunked"] is True
         assert call_kwargs["chunk_size"] == 1048576
+
+    def test_dry_run_rejects_tag_override_with_multiple_manifests(self, tmp_path):
+        layout_dir = _build_multi_manifest_layout(tmp_path)
+
+        result = _runner().invoke(regshape, [
+            "layout", "push",
+            "--path", str(layout_dir),
+            "--dest", "registry.io/myrepo:custom_tag",
+            "--dry-run",
+        ])
+        assert result.exit_code != 0
+        assert "tag override" in result.output.lower() or "multiple" in result.output.lower()

--- a/src/regshape/tests/test_layout_push.py
+++ b/src/regshape/tests/test_layout_push.py
@@ -314,7 +314,7 @@ class TestPushCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "push",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--dest", "registry.io/myrepo:latest",
         ])
         assert result.exit_code == 0, result.output
@@ -348,7 +348,7 @@ class TestPushCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "push",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--dest", "registry.io/myrepo:latest",
             "--json",
         ])
@@ -362,7 +362,7 @@ class TestPushCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "push",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--dest", "registry.io/myrepo:latest",
             "--dry-run",
         ])
@@ -376,7 +376,7 @@ class TestPushCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "push",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--dest", "registry.io/myrepo:latest",
             "--dry-run",
             "--json",
@@ -392,7 +392,7 @@ class TestPushCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "push",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--dest", "nope",
         ])
         assert result.exit_code != 0
@@ -405,7 +405,7 @@ class TestPushCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "push",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--dest", "registry.io/myrepo:latest",
         ])
         assert result.exit_code == 1
@@ -425,7 +425,7 @@ class TestPushCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "push",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--dest", "registry.io/myrepo:latest",
             "--force",
         ])
@@ -449,7 +449,7 @@ class TestPushCLI:
 
         result = _runner().invoke(regshape, [
             "layout", "push",
-            "--layout", str(layout_dir),
+            "--path", str(layout_dir),
             "--dest", "registry.io/myrepo:latest",
             "--chunked",
             "--chunk-size", "1048576",

--- a/src/regshape/tests/test_transport_models.py
+++ b/src/regshape/tests/test_transport_models.py
@@ -175,7 +175,7 @@ class TestRegistryResponse:
     def test_non_dict_headers_raises_error(self):
         mock_response = MagicMock()
         
-        with pytest.raises(TypeError, match="RegistryResponse\\.headers must be a dict"):
+        with pytest.raises(TypeError, match="RegistryResponse\\.headers must be a mapping"):
             RegistryResponse(
                 status_code=200,
                 headers="not-a-dict",

--- a/src/regshape/tests/test_transport_models.py
+++ b/src/regshape/tests/test_transport_models.py
@@ -257,7 +257,7 @@ class TestRegistryResponse:
         assert chunks == [b"chunk1", b"chunk2"]
         mock_response.iter_content.assert_called_once_with(chunk_size=1024)
 
-    def test_headers_converted_to_dict(self):
+    def test_headers_preserve_case_insensitive_lookup(self):
         """Test that from_requests_response preserves case-insensitive headers."""
         mock_response = MagicMock()
         mock_response.status_code = 200

--- a/src/regshape/tests/test_transport_models.py
+++ b/src/regshape/tests/test_transport_models.py
@@ -258,22 +258,18 @@ class TestRegistryResponse:
         mock_response.iter_content.assert_called_once_with(chunk_size=1024)
 
     def test_headers_converted_to_dict(self):
-        """Test that from_requests_response converts headers properly."""
+        """Test that from_requests_response preserves case-insensitive headers."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.content = b""
-        
-        # Create a simple dict-like object for headers
-        class MockHeaders:
-            def __init__(self):
-                self.data = {"Content-Type": "application/json", "Content-Length": "123"}
-            
-            def __iter__(self):
-                return iter(self.data.items())
-        
-        mock_response.headers = MockHeaders()
-        
+
+        # Use a requests-style CaseInsensitiveDict
+        from requests.structures import CaseInsensitiveDict
+        mock_response.headers = CaseInsensitiveDict(
+            {"Content-Type": "application/json", "Content-Length": "123"}
+        )
+
         resp = RegistryResponse.from_requests_response(mock_response)
-        assert isinstance(resp.headers, dict)
-        assert resp.headers["Content-Type"] == "application/json"
-        assert resp.headers["Content-Length"] == "123"
+        # Case-insensitive lookup must work
+        assert resp.headers["content-type"] == "application/json"
+        assert resp.headers["CONTENT-LENGTH"] == "123"


### PR DESCRIPTION
## Summary

Implement OCI layout push functionality and harden the authentication flow.

## Changes

### OCI Layout Push (`layout push` command)
- Add `layout push` subcommand to push an OCI layout directory to a remote registry
- Support progress bars for blob and manifest uploads
- Skip blobs already present in the registry (existence check via HEAD)
- Add `--path`/`-p` option across all layout subcommands (create, validate, push) for consistency

### Authentication Hardening
- **credsStore fallback**: Fall back to Docker `credsStore` when `credHelpers` has no entry for the target registry
- **OAuth2 refresh token exchange**: Add POST-based `grant_type=refresh_token` fallback for registries (e.g. ACR) that store JWT refresh tokens via credential helpers
- **Centralize auth logic**: Refactor `_verify_credentials()` in `auth login` CLI to use `RegistryClient` instead of hand-rolled HTTP, eliminating duplicate auth flow
- **Quote-aware header parsing**: Fix `_parse_auth_header()` to handle commas inside quoted values (e.g. `scope="repository:repo:pull,push"`)
- **Case-insensitive auth scheme**: Compare scheme names (Bearer/Basic) case-insensitively per RFC 7235
- **Preserve CaseInsensitiveDict**: Keep `requests.structures.CaseInsensitiveDict` in `RegistryResponse` instead of converting to plain `dict`, per RFC 7230

### Specs & Docs
- Add specification for `layout push` command
- Update layout CLI spec and user guide for unified `--path`/`-p` option

## Testing
- Add tests for push operations (blob upload, manifest push, existence checks, progress tracking)
- Add tests for refresh token fallback, comma-in-scope parsing, case-insensitive scheme matching
- Add tests for `credsStore` fallback and `CaseInsensitiveDict` preservation
- 15 files changed, ~1,640 insertions

Closes #40