### PR TITLE
Docker Desktop Integration - Export and Push Local Images

### DIFF
--- a/docs/guides/docker-desktop-integration.md
+++ b/docs/guides/docker-desktop-integration.md
@@ -1,0 +1,227 @@
+# Guide: Docker Desktop Integration
+
+This guide shows how to use `regshape` to interact with your local Docker
+Desktop images — listing them, exporting them as OCI Image Layouts, and pushing
+them directly to remote OCI registries.
+
+## Prerequisites
+
+- **Docker Desktop** must be running (the Docker daemon must be reachable).
+- The `docker` Python SDK is installed (`pip install docker>=7.0.0`).
+
+You can verify connectivity with:
+
+```bash
+regshape docker list
+```
+
+If Docker Desktop is not running you will see:
+
+```
+Error [docker list]: Cannot connect to Docker daemon. Is Docker Desktop running?
+```
+
+---
+
+## Listing local images
+
+List all images available in your local Docker store:
+
+```bash
+regshape docker list
+```
+
+```
+REPOSITORY                     TAG             IMAGE ID       SIZE       CREATED
+nginx                          latest          a8758716bb6a   187MB      2025-12-01T10:30:00Z
+python                         3.12            b5d5cef26b2a   1.02GB     2025-11-15T08:00:00Z
+```
+
+### Filtering by name
+
+Use `--filter` to show only images whose name contains a substring:
+
+```bash
+regshape docker list --filter nginx
+```
+
+### JSON output
+
+Add `--json` for machine-readable output:
+
+```bash
+regshape docker list --json
+```
+
+```json
+[
+  {
+    "id": "sha256:a8758716bb6a...",
+    "repo_tags": ["nginx:latest"],
+    "repo_digests": ["nginx@sha256:..."],
+    "size": 196083713,
+    "created": "2025-12-01T10:30:00Z",
+    "architecture": "amd64",
+    "os": "linux"
+  }
+]
+```
+
+---
+
+## Exporting an image as an OCI layout
+
+Export a Docker image to a local directory as a valid
+[OCI Image Layout](https://github.com/opencontainers/image-spec/blob/main/image-layout.md):
+
+```bash
+regshape docker export --image nginx:latest --output ./nginx-oci
+```
+
+```
+Exported nginx:latest to OCI layout at ./nginx-oci
+```
+
+The resulting directory has the standard OCI Image Layout structure:
+
+```
+nginx-oci/
+├── oci-layout
+├── index.json
+└── blobs/
+    └── sha256/
+        ├── <manifest-digest>
+        ├── <config-digest>
+        ├── <layer-digest>
+        └── ...
+```
+
+### Key details
+
+- **Layers are always gzip-compressed** in the output layout, ensuring
+  consistent `application/vnd.oci.image.layer.v1.tar+gzip` media types.
+- The Docker config JSON is converted to OCI Image Config format
+  (Docker-proprietary fields are stripped; standard OCI fields are preserved).
+- The output directory must not already exist as an OCI layout or contain
+  other files. Use a fresh directory for each export.
+
+### Multi-platform images
+
+Docker Desktop can store multi-architecture images built with `docker buildx`.
+By default, all platform variants are exported:
+
+```bash
+regshape docker export --image myapp:latest --output ./myapp-oci
+```
+
+The resulting `index.json` will contain one manifest descriptor per platform,
+each with a `platform` object:
+
+```json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:aaa...",
+      "size": 528,
+      "platform": { "architecture": "amd64", "os": "linux" }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:bbb...",
+      "size": 531,
+      "platform": { "architecture": "arm64", "os": "linux" }
+    }
+  ]
+}
+```
+
+### Exporting a single platform
+
+Use `--platform` to export only one variant:
+
+```bash
+regshape docker export --image myapp:latest --output ./myapp-amd64 --platform linux/amd64
+```
+
+If the requested platform is not available, the command exits with an error
+listing the available platforms.
+
+---
+
+## Pushing a Docker image to a remote registry
+
+Push a local Docker image directly to an OCI-compliant registry without
+manually exporting first:
+
+```bash
+regshape docker push --image nginx:latest --dest registry.io/myrepo/nginx:v1
+```
+
+```
+Pushed nginx:latest to registry.io/myrepo/nginx:v1: 1 manifest(s), 5 blob(s) uploaded, 0 blob(s) skipped
+```
+
+Under the hood, `regshape docker push` creates a temporary OCI layout, then
+uses the existing `push_layout` infrastructure to upload blobs and manifests.
+
+### Authentication
+
+Registry credentials are resolved from the Docker credential store (the same
+credentials used by `regshape auth login`). If the registry requires
+authentication and no credentials are found, the push will fail with an auth
+error.
+
+### Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--image` | `-i` | Docker image reference (required) |
+| `--dest` | `-d` | Destination registry reference (required) |
+| `--platform` | | Export and push only one platform variant |
+| `--force` | | Skip blob existence checks; upload everything |
+| `--chunked` | | Use chunked (streaming) blob uploads |
+| `--chunk-size` | | Chunk size in bytes (default: 65536) |
+| `--json` | | Output as JSON |
+
+### Pushing to a local registry
+
+For testing, you can push to a local registry:
+
+```bash
+# Start a local registry
+docker run -d -p 5000:5000 --name registry registry:2
+
+# Push with --insecure (HTTP instead of HTTPS)
+regshape --insecure docker push --image nginx:latest --dest localhost:5000/nginx:latest
+
+# Verify
+regshape tag list -i localhost:5000/nginx --insecure
+```
+
+### Multi-platform push
+
+Multi-platform images are pushed correctly — shared blobs between platforms
+are deduplicated via the blob existence check (`HEAD` request before upload).
+
+```bash
+# Push all platforms
+regshape docker push --image myapp:latest --dest registry.io/myrepo/myapp:v1
+
+# Push only one platform
+regshape docker push --image myapp:latest --dest registry.io/myrepo/myapp:v1 --platform linux/amd64
+```
+
+---
+
+## Error handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| Cannot connect to Docker daemon | Docker Desktop is not running | Start Docker Desktop |
+| Image not found in local Docker store | Image name/tag does not exist locally | Run `regshape docker list` to check available images |
+| Output directory is already an OCI Image Layout | Previous export exists at the path | Remove the directory or use a new path |
+| Output directory already exists and is not empty | Non-empty directory at the output path | Use an empty or non-existent directory |
+| Platform not available | Requested platform variant does not exist | Check available platforms in the error message |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click>=8.1.0
+docker>=7.0.0
 pytest>=7.4.0
 requests>=2.31.0

--- a/specs/docker/docker-desktop-integration.md
+++ b/specs/docker/docker-desktop-integration.md
@@ -1,0 +1,412 @@
+# Docker Desktop Integration — Export and Push Local Images
+
+## Overview
+
+Add a `regshape docker` command group that bridges Docker Desktop's local
+image store with the OCI ecosystem. It connects to the local Docker daemon
+via the Docker Engine API (using the `docker` Python SDK), lets users list
+available images, export them as OCI Image Layouts on disk, and push them
+directly to a remote OCI-compliant registry. Multi-platform images (manifest
+lists) are fully supported.
+
+---
+
+## Module Structure
+
+```
+src/regshape/libs/docker/
+├── __init__.py        # Re-exports public symbols
+└── operations.py      # list_images, export_image, push_image + conversion helpers
+
+src/regshape/cli/docker.py   # Click commands: list, export, push
+```
+
+---
+
+## Dependency
+
+**New external dependency:** `docker>=7.0.0` (the official Docker SDK for
+Python). Added to `requirements.txt`.
+
+The `docker` SDK communicates with the Docker Engine daemon over the Unix
+socket (`/var/run/docker.sock`) on Linux/macOS or the named pipe on Windows.
+It handles connection negotiation and API versioning automatically via
+`docker.from_env()`.
+
+---
+
+## Library Layer — `libs/docker/operations.py`
+
+### `list_images()`
+
+```python
+def list_images(name_filter: str | None = None) -> list[DockerImageInfo]:
+```
+
+Connects to the local Docker daemon and returns a list of available images.
+
+- Uses `docker.from_env().images.list()` internally.
+- Optionally filters by repository name if `name_filter` is provided.
+- Returns a list of `DockerImageInfo` dataclasses (see Data Models below).
+- Raises `DockerError` if the daemon is unreachable or returns an error.
+
+### `export_image()`
+
+```python
+def export_image(
+    image_ref: str,
+    output_path: str | Path,
+    *,
+    platform: str | None = None,
+) -> None:
+```
+
+Exports a Docker image as a valid OCI Image Layout directory.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `image_ref` | `str` | Docker image reference (name:tag or image ID) |
+| `output_path` | `str \| Path` | Filesystem path for the OCI layout output |
+| `platform` | `str \| None` | Platform filter in `os/architecture` format (e.g. `linux/amd64`). When `None`, all available platforms are exported. |
+
+**Algorithm:**
+
+1. Connect to the Docker daemon; resolve `image_ref` to an image object
+   (`client.images.get(image_ref)`).
+2. Inspect the image to determine whether it is a single-platform image or a
+   multi-platform manifest list.
+3. Call `image.save()` to obtain the Docker save tar stream.
+4. Extract the tar in-memory (or to a temp directory).
+5. Parse `manifest.json` (Docker save format) to discover layers and config
+   for each platform variant.
+6. Convert to OCI Image Layout:
+   - Create the OCI layout scaffold at `output_path` (reuse `init_layout()`
+     from `libs/layout/`).
+   - **For each platform variant** (or the single image if not multi-platform):
+     a. For each layer tarball, gzip-compress it and write as a blob via
+        `add_blob()`.
+     b. Convert the Docker config JSON to OCI Image Config format, write via
+        `add_blob()`.
+     c. Build an OCI Image Manifest referencing the config and layers with
+        correct OCI media types.
+     d. Write the manifest via `add_blob()` and record its descriptor.
+   - **If multi-platform:** Build an OCI Image Index with `manifests` array
+     containing a descriptor for each platform manifest, each annotated with
+     `platform.os` and `platform.architecture`. Write the index as the
+     top-level entry in `index.json`.
+   - **If single-platform:** Register the single manifest directly in
+     `index.json`.
+7. Raises `DockerError` on daemon errors, `LayoutError` on filesystem errors.
+
+**Compression:** Layers are always gzip-compressed when written to the OCI
+layout, regardless of the compression state in the Docker save tar. This
+ensures consistency with OCI conventions and produces layouts with
+`application/vnd.oci.image.layer.v1.tar+gzip` media types throughout.
+
+**Docker-save-to-OCI conversion details:**
+
+| Docker save artifact | OCI layout artifact | Media type |
+|---|---|---|
+| `<layer-id>/layer.tar` | `blobs/sha256/<digest>` (gzip-compressed) | `application/vnd.oci.image.layer.v1.tar+gzip` |
+| `<config-digest>.json` | `blobs/sha256/<digest>` | `application/vnd.oci.image.config.v1+json` |
+| (generated per platform) | `blobs/sha256/<digest>` | `application/vnd.oci.image.manifest.v1+json` |
+| (generated, multi-platform only) | registered in `index.json` | `application/vnd.oci.image.index.v1+json` |
+
+The Docker config JSON is largely compatible with the OCI Image Config spec.
+The main conversion steps are: verifying the `mediaType` and stripping any
+Docker-proprietary fields that have no OCI equivalent, while preserving
+`architecture`, `os`, `rootfs`, `config` (env, cmd, entrypoint, labels,
+etc.), and `history`.
+
+### `push_image()`
+
+```python
+def push_image(
+    image_ref: str,
+    dest: str,
+    *,
+    platform: str | None = None,
+    insecure: bool = False,
+    force: bool = False,
+    chunked: bool = False,
+    chunk_size: int = 65536,
+) -> PushResult:
+```
+
+Exports a Docker image and pushes it to a remote registry.
+
+**Algorithm:**
+
+1. Create a temporary directory.
+2. Call `export_image(image_ref, temp_dir, platform=platform)` to produce an
+   OCI layout.
+3. Parse `dest` via `parse_image_ref()` to get `(registry, repo, reference)`.
+4. Build a `RegistryClient` with `TransportConfig`.
+5. Call `push_layout()` from `libs/layout/` to push the OCI layout to the
+   remote registry.
+6. Clean up the temporary directory.
+7. Return a `PushResult` (the existing dataclass from `libs/layout/`).
+
+This maximizes reuse — the network push logic is already implemented.
+
+---
+
+## Multi-Platform Image Support
+
+Docker Desktop can store multi-architecture images built with `docker buildx`.
+The feature handles these as follows:
+
+### Detection
+
+When `image.save()` produces a tar whose `manifest.json` contains multiple
+entries (one per platform), the export pipeline treats the image as
+multi-platform.
+
+### Export Behaviour
+
+| Scenario | `--platform` flag | Result |
+|---|---|---|
+| Single-platform image | omitted | Exports the image as a single manifest in `index.json` |
+| Single-platform image | provided | Validates the platform matches; exports normally |
+| Multi-platform image | omitted | Exports **all** platform variants; `index.json` contains one manifest descriptor per platform |
+| Multi-platform image | `linux/amd64` | Exports **only** the matching platform variant as a single manifest |
+
+### OCI Layout Structure (Multi-Platform)
+
+```
+<output-dir>/
+├── oci-layout
+├── index.json              # OCI Image Index with per-platform manifest descriptors
+└── blobs/
+    └── sha256/
+        ├── <manifest-amd64>     # OCI manifest for linux/amd64
+        ├── <manifest-arm64>     # OCI manifest for linux/arm64
+        ├── <config-amd64>
+        ├── <config-arm64>
+        ├── <layer-shared>       # Shared layers written once (content-addressed dedup)
+        ├── <layer-amd64-only>
+        └── <layer-arm64-only>
+```
+
+Each manifest descriptor in `index.json` carries a `platform` object:
+
+```json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:aaa...",
+      "size": 528,
+      "platform": { "architecture": "amd64", "os": "linux" }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:bbb...",
+      "size": 531,
+      "platform": { "architecture": "arm64", "os": "linux" }
+    }
+  ]
+}
+```
+
+### Push Behaviour
+
+`push_layout()` already iterates over all manifests in `index.json`, so
+multi-platform layouts are pushed correctly without additional logic. Shared
+blobs between platforms are deduplicated via the existing `HEAD` existence
+check.
+
+---
+
+## Data Models
+
+```python
+@dataclass
+class DockerImageInfo:
+    """Summary of a local Docker image."""
+    id: str                    # Short image ID (sha256 prefix)
+    repo_tags: list[str]       # e.g. ["nginx:latest", "nginx:1.25"]
+    repo_digests: list[str]    # e.g. ["nginx@sha256:abc..."]
+    size: int                  # Image size in bytes
+    created: str               # ISO 8601 timestamp
+    architecture: str          # e.g. "amd64"
+    os: str                    # e.g. "linux"
+```
+
+Defined in `libs/docker/operations.py` (kept co-located since it is
+domain-specific).
+
+---
+
+## Error Handling
+
+New error type in `libs/errors.py`:
+
+```python
+class DockerError(RegShapeError):
+    """Raised when a Docker daemon interaction fails."""
+    pass
+```
+
+| Condition | Error | Message |
+|---|---|---|
+| Daemon not running / socket unavailable | `DockerError` | `"Cannot connect to Docker daemon. Is Docker Desktop running?"` |
+| Image not found locally | `DockerError` | `"Image '{ref}' not found in local Docker store"` |
+| Platform not found in multi-platform image | `DockerError` | `"Platform '{platform}' not available for image '{ref}'. Available: {list}"` |
+| Docker API error | `DockerError` | Wraps the underlying SDK exception message |
+
+---
+
+## CLI Layer — `cli/docker.py`
+
+### Command Group
+
+```
+regshape docker <subcommand>
+```
+
+Wired into `cli/main.py` via `regshape.add_command(docker)`.
+
+### `regshape docker list`
+
+```
+regshape docker list [OPTIONS]
+```
+
+| Option | Short | Type | Default | Description |
+|---|---|---|---|---|
+| `--filter` | `-f` | string | `None` | Filter by image name (substring match) |
+| `--json` | | flag | `false` | Output as JSON |
+
+**Default output** (table):
+
+```
+REPOSITORY          TAG       IMAGE ID       SIZE       CREATED
+nginx               latest    a8758716bb6a   187MB      2025-12-01T10:30:00Z
+python              3.12      b5d5cef26b2a   1.02GB     2025-11-15T08:00:00Z
+```
+
+**JSON output** (`--json`):
+
+```json
+[
+  {
+    "id": "sha256:a8758716bb6a...",
+    "repo_tags": ["nginx:latest"],
+    "repo_digests": ["nginx@sha256:..."],
+    "size": 196083713,
+    "created": "2025-12-01T10:30:00Z",
+    "architecture": "amd64",
+    "os": "linux"
+  }
+]
+```
+
+### `regshape docker export`
+
+```
+regshape docker export [OPTIONS]
+```
+
+| Option | Short | Type | Default | Description |
+|---|---|---|---|---|
+| `--image` | `-i` | string | required | Docker image reference (name:tag or ID) |
+| `--output` | `-o` | path | required | Output directory for the OCI layout |
+| `--platform` | | string | `None` | Platform filter (`os/architecture`, e.g. `linux/amd64`). Omit to export all platforms. |
+| `--json` | | flag | `false` | Output as JSON |
+
+**Behaviour:**
+
+1. Call `export_image(image, output, platform=platform)`.
+2. Print summary (number of layers, total size, output path, platforms
+   exported).
+3. Exit 0 on success, 1 on error.
+
+### `regshape docker push`
+
+```
+regshape docker push [OPTIONS]
+```
+
+| Option | Short | Type | Default | Description |
+|---|---|---|---|---|
+| `--image` | `-i` | string | required | Docker image reference (name:tag or ID) |
+| `--dest` | `-d` | string | required | Destination registry reference (`registry/repo[:tag]`) |
+| `--platform` | | string | `None` | Platform filter (`os/architecture`). Omit to push all platforms. |
+| `--force` | | flag | `false` | Skip blob existence checks |
+| `--chunked` | | flag | `false` | Use chunked upload |
+| `--chunk-size` | | integer | `65536` | Chunk size for chunked upload |
+| `--json` | | flag | `false` | Output as JSON |
+
+**Behaviour:**
+
+1. Call `push_image(image, dest, platform=platform, insecure=..., force=...,
+   chunked=..., chunk_size=...)`.
+2. Print push summary (blobs uploaded, blobs skipped, manifest digest,
+   platforms pushed).
+3. Exit 0 on success, 1 on error.
+
+Inherits global options `--insecure`, `--verbose`, `--log-file` from the
+parent group.
+
+---
+
+## Wiring in `main.py`
+
+```python
+from regshape.cli.docker import docker
+regshape.add_command(docker)
+```
+
+---
+
+## Dependencies / Reuse
+
+| Existing module | Reused by |
+|---|---|
+| `libs/layout/init_layout` | `export_image` — scaffold the OCI layout directory |
+| `libs/layout/add_blob` | `export_image` — write layers and config as blobs |
+| `libs/layout/add_manifest` | `export_image` — write the OCI manifest |
+| `libs/layout/push_layout` | `push_image` — push OCI layout to remote registry |
+| `libs/layout/PushResult` | `push_image` — return type |
+| `libs/refs/parse_image_ref` | CLI push — parse destination reference |
+| `libs/transport/RegistryClient` | `push_image` (via `push_layout`) |
+| `libs/auth/` | Credentials resolved automatically for registry push |
+
+---
+
+## Files to Create / Modify
+
+| File | Action |
+|---|---|
+| `src/regshape/libs/docker/__init__.py` | Create |
+| `src/regshape/libs/docker/operations.py` | Create |
+| `src/regshape/cli/docker.py` | Create |
+| `src/regshape/cli/main.py` | Modify (add docker command group) |
+| `src/regshape/libs/errors.py` | Modify (add `DockerError`) |
+| `requirements.txt` | Modify (add `docker>=7.0.0`) |
+| `src/regshape/tests/test_docker_operations.py` | Create |
+| `src/regshape/tests/test_docker_cli.py` | Create |
+| `specs/docker/docker-desktop-integration.md` | Create (this spec) |
+| `docs/guides/docker-desktop-integration.md` | Create |
+
+---
+
+## Testing Strategy
+
+All tests mock the Docker SDK — no real daemon required.
+
+- **`test_docker_operations.py`**: Unit tests for `list_images`,
+  `export_image`, `push_image`. Mock `docker.from_env()` and
+  `image.save()`. Verify OCI layout structure for export. Test both
+  single-platform and multi-platform code paths. Verify platform filtering
+  selects the correct variant. Verify gzip compression is always applied to
+  layers. Verify `push_layout` is called correctly for push.
+- **`test_docker_cli.py`**: CLI invocation tests using Click's `CliRunner`.
+  Mock the library functions. Verify output format (plain text and JSON),
+  `--platform` option handling, error messages (including
+  platform-not-found), and exit codes.

--- a/src/regshape/cli/docker.py
+++ b/src/regshape/cli/docker.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+
+"""
+:mod:`regshape.cli.docker` - CLI commands for Docker Desktop integration
+========================================================================
+
+.. module:: regshape.cli.docker
+   :platform: Unix, Windows
+   :synopsis: Click command group providing ``list``, ``export``, and ``push``
+              subcommands for interacting with local Docker Desktop images.
+
+.. moduleauthor:: ToddySM <toddysm@gmail.com>
+"""
+
+import json
+import sys
+
+import click
+
+from regshape.libs.docker import export_image, list_images, push_image
+from regshape.libs.errors import AuthError, BlobError, DockerError, LayoutError, ManifestError
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+
+def _format_size(size_bytes: int) -> str:
+    """Format a byte count as a human-readable size string."""
+    if size_bytes >= 1_073_741_824:
+        return f"{size_bytes / 1_073_741_824:.2f}GB"
+    if size_bytes >= 1_048_576:
+        return f"{size_bytes / 1_048_576:.0f}MB"
+    if size_bytes >= 1024:
+        return f"{size_bytes / 1024:.0f}KB"
+    return f"{size_bytes}B"
+
+
+def _error(context: str, reason: str) -> None:
+    """Print an error message to stderr."""
+    click.echo(f"Error [{context}]: {reason}", err=True)
+
+
+# ===========================================================================
+# Public Click group
+# ===========================================================================
+
+
+@click.group()
+def docker():
+    """Interact with Docker Desktop local images."""
+    pass
+
+
+# ===========================================================================
+# docker list
+# ===========================================================================
+
+
+@docker.command("list")
+@click.option(
+    "--filter", "-f", "name_filter",
+    default=None,
+    metavar="NAME",
+    help="Filter images by name (substring match).",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output JSON.")
+@click.pass_context
+def list_cmd(ctx, name_filter, as_json):
+    """List images available in the local Docker daemon."""
+    try:
+        images = list_images(name_filter=name_filter)
+    except DockerError as exc:
+        _error("docker list", str(exc))
+        sys.exit(1)
+
+    if as_json:
+        output = [
+            {
+                "id": img.id,
+                "repo_tags": img.repo_tags,
+                "repo_digests": img.repo_digests,
+                "size": img.size,
+                "created": img.created,
+                "architecture": img.architecture,
+                "os": img.os,
+            }
+            for img in images
+        ]
+        click.echo(json.dumps(output, indent=2))
+    else:
+        if not images:
+            click.echo("No images found.")
+            return
+
+        # Table header
+        header = f"{'REPOSITORY':<30} {'TAG':<15} {'IMAGE ID':<14} {'SIZE':<10} {'CREATED'}"
+        click.echo(header)
+
+        for img in images:
+            if img.repo_tags:
+                for tag in img.repo_tags:
+                    parts = tag.rsplit(":", 1)
+                    repo = parts[0] if len(parts) == 2 else tag
+                    tag_name = parts[1] if len(parts) == 2 else "<none>"
+                    short_id = img.id[:19] if len(img.id) > 19 else img.id
+                    # Strip sha256: prefix for display
+                    if short_id.startswith("sha256:"):
+                        short_id = short_id[7:19]
+                    size_str = _format_size(img.size)
+                    click.echo(
+                        f"{repo:<30} {tag_name:<15} {short_id:<14} {size_str:<10} {img.created}"
+                    )
+            else:
+                short_id = img.id[:19] if len(img.id) > 19 else img.id
+                if short_id.startswith("sha256:"):
+                    short_id = short_id[7:19]
+                size_str = _format_size(img.size)
+                click.echo(
+                    f"{'<none>':<30} {'<none>':<15} {short_id:<14} {size_str:<10} {img.created}"
+                )
+
+
+# ===========================================================================
+# docker export
+# ===========================================================================
+
+
+@docker.command("export")
+@click.option(
+    "--image", "-i",
+    required=True,
+    metavar="IMAGE",
+    help="Docker image reference (name:tag or ID).",
+)
+@click.option(
+    "--output", "-o",
+    required=True,
+    type=click.Path(),
+    metavar="DIR",
+    help="Output directory for the OCI Image Layout.",
+)
+@click.option(
+    "--platform",
+    default=None,
+    metavar="OS/ARCH",
+    help="Platform filter (e.g. linux/amd64). Omit to export all platforms.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output JSON.")
+@click.pass_context
+def export_cmd(ctx, image, output, platform, as_json):
+    """Export a Docker image as an OCI Image Layout on disk."""
+    try:
+        export_image(image, output, platform=platform)
+    except (DockerError, LayoutError) as exc:
+        _error("docker export", str(exc))
+        sys.exit(1)
+
+    if as_json:
+        result = {
+            "image": image,
+            "output": str(output),
+        }
+        if platform:
+            result["platform"] = platform
+        click.echo(json.dumps(result, indent=2))
+    else:
+        msg = f"Exported {image} to OCI layout at {output}"
+        if platform:
+            msg += f" (platform: {platform})"
+        click.echo(msg)
+
+
+# ===========================================================================
+# docker push
+# ===========================================================================
+
+
+@docker.command("push")
+@click.option(
+    "--image", "-i",
+    required=True,
+    metavar="IMAGE",
+    help="Docker image reference (name:tag or ID).",
+)
+@click.option(
+    "--dest", "-d",
+    required=True,
+    metavar="REFERENCE",
+    help="Destination registry reference (registry/repo[:tag]).",
+)
+@click.option(
+    "--platform",
+    default=None,
+    metavar="OS/ARCH",
+    help="Platform filter (e.g. linux/amd64). Omit to push all platforms.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Skip blob existence checks; upload all blobs unconditionally.",
+)
+@click.option(
+    "--chunked",
+    is_flag=True,
+    default=False,
+    help="Use chunked (streaming) blob upload protocol.",
+)
+@click.option(
+    "--chunk-size",
+    type=int,
+    default=65536,
+    metavar="BYTES",
+    help="Chunk size in bytes for chunked uploads.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output JSON.")
+@click.pass_context
+def push_cmd(ctx, image, dest, platform, force, chunked, chunk_size, as_json):
+    """Push a Docker image to a remote OCI registry."""
+    insecure = ctx.obj.get("insecure", False) if ctx.obj else False
+
+    try:
+        result = push_image(
+            image,
+            dest,
+            platform=platform,
+            insecure=insecure,
+            force=force,
+            chunked=chunked,
+            chunk_size=chunk_size,
+        )
+    except (DockerError, LayoutError, AuthError, BlobError, ManifestError) as exc:
+        _error("docker push", str(exc))
+        sys.exit(1)
+
+    if as_json:
+        output = {
+            "image": image,
+            "destination": dest,
+            "manifests_pushed": len(result.manifests),
+            "blobs_uploaded": sum(
+                1 for m in result.manifests for b in m.blobs if b.uploaded
+            ),
+            "blobs_skipped": sum(
+                1 for m in result.manifests for b in m.blobs if not b.uploaded
+            ),
+        }
+        if platform:
+            output["platform"] = platform
+        click.echo(json.dumps(output, indent=2))
+    else:
+        total_manifests = len(result.manifests)
+        total_uploaded = sum(
+            1 for m in result.manifests for b in m.blobs if b.uploaded
+        )
+        total_skipped = sum(
+            1 for m in result.manifests for b in m.blobs if not b.uploaded
+        )
+        click.echo(
+            f"Pushed {image} to {dest}: "
+            f"{total_manifests} manifest(s), "
+            f"{total_uploaded} blob(s) uploaded, "
+            f"{total_skipped} blob(s) skipped"
+        )

--- a/src/regshape/cli/main.py
+++ b/src/regshape/cli/main.py
@@ -17,6 +17,7 @@ import click
 from regshape.cli.auth import auth
 from regshape.cli.blob import blob
 from regshape.cli.catalog import catalog
+from regshape.cli.docker import docker
 from regshape.cli.layout import layout
 from regshape.cli.manifest import manifest
 from regshape.cli.referrer import referrer
@@ -68,6 +69,7 @@ def regshape(
 regshape.add_command(auth)
 regshape.add_command(blob)
 regshape.add_command(catalog)
+regshape.add_command(docker)
 regshape.add_command(layout)
 regshape.add_command(manifest)
 regshape.add_command(referrer)

--- a/src/regshape/libs/docker/__init__.py
+++ b/src/regshape/libs/docker/__init__.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+"""
+:mod:`regshape.libs.docker` - Docker Desktop integration operations
+====================================================================
+
+.. module:: regshape.libs.docker
+   :platform: Unix, Windows
+   :synopsis: Library-level functions for listing, exporting, and pushing
+              Docker Desktop images as OCI Image Layouts.
+
+.. moduleauthor:: ToddySM <toddysm@gmail.com>
+"""
+
+from regshape.libs.docker.operations import (
+    DockerImageInfo,
+    export_image,
+    list_images,
+    push_image,
+)
+
+__all__ = [
+    "DockerImageInfo",
+    "export_image",
+    "list_images",
+    "push_image",
+]

--- a/src/regshape/libs/docker/operations.py
+++ b/src/regshape/libs/docker/operations.py
@@ -125,10 +125,10 @@ def _parse_platform_string(platform_str: str) -> tuple[str, str]:
     return parts[0], parts[1]
 
 
-def _extract_docker_save_tar(image_ref: str, client: docker_sdk.DockerClient) -> tuple[dict, tarfile.TarFile, bytes]:
+def _extract_docker_save_tar(image_ref: str, client: docker_sdk.DockerClient) -> tuple[list[dict], tarfile.TarFile, bytes]:
     """Save a Docker image and extract its tar contents.
 
-    :returns: Tuple of (parsed manifest.json list, TarFile object, raw tar bytes).
+    :returns: Tuple of (parsed ``manifest.json`` list of dicts, TarFile object, raw tar bytes).
     :raises DockerError: On image-not-found or API errors.
     """
     try:

--- a/src/regshape/libs/docker/operations.py
+++ b/src/regshape/libs/docker/operations.py
@@ -377,6 +377,11 @@ def export_image(
 ) -> None:
     """Export a Docker image as an OCI Image Layout directory.
 
+        if not output.is_dir():
+            raise LayoutError(
+                f"Output path {output} exists and is not a directory",
+                "use a directory path for the OCI Image Layout or remove/rename the existing file",
+            )
     Layers are always gzip-compressed. Multi-platform images are fully
     supported: when *platform* is ``None`` all variants are exported,
     otherwise only the matching platform is included.

--- a/src/regshape/libs/docker/operations.py
+++ b/src/regshape/libs/docker/operations.py
@@ -410,6 +410,7 @@ def export_image(
 
     manifest_descriptors: list[Descriptor] = []
 
+    available_platforms = []
     for entry in docker_manifests:
         # Read config to get platform info
         config_path = entry["Config"]
@@ -420,6 +421,8 @@ def export_image(
 
         # Apply platform filter
         if platform is not None:
+            # Record available platforms for error reporting if no match is found
+            available_platforms.append(f"{img_os}/{img_arch}")
             if img_os != filter_os or img_arch != filter_arch:
                 continue
 
@@ -440,24 +443,9 @@ def export_image(
 
     if not manifest_descriptors:
         if platform is not None:
-            # Collect available platforms for the error message
-            available = []
-            for entry in docker_manifests:
-                config_path = entry["Config"]
-                # Re-open tar to read configs (tar was closed)
-                tar_buffer = io.BytesIO()
-                # We need the raw tar bytes — re-extract from docker
-                client2 = _get_docker_client()
-                docker_manifests2, tar2, _ = _extract_docker_save_tar(image_ref, client2)
-                for e2 in docker_manifests2:
-                    c = _read_tar_member(tar2, e2["Config"])
-                    cj = json.loads(c)
-                    available.append(f"{cj.get('os', '?')}/{cj.get('architecture', '?')}")
-                tar2.close()
-                break
             raise DockerError(
                 f"Platform {platform!r} not available for image {image_ref!r}",
-                f"Available: {', '.join(available)}",
+                f"Available: {', '.join(available_platforms)}",
             )
         raise DockerError(
             f"No images found to export for {image_ref!r}",

--- a/src/regshape/libs/docker/operations.py
+++ b/src/regshape/libs/docker/operations.py
@@ -145,31 +145,25 @@ def _extract_docker_save_tar(image_ref: str, client: docker_sdk.DockerClient) ->
             str(exc),
         ) from exc
 
-        # Stream the docker save output into a temporary file to avoid
-        # accumulating the entire tar archive in memory via a chunk list.
-        tmp_file = tempfile.SpooledTemporaryFile()
+    try:
         chunks = []
-            tmp_file.write(chunk)
-        tmp_file.seek(0)
+        for chunk in image.save(named=True):
+            chunks.append(chunk)
         tar_bytes = b"".join(chunks)
     except APIError as exc:
         raise DockerError(
             f"Docker API error while saving image {image_ref!r}",
             str(exc),
         ) from exc
+
     tar_buffer = io.BytesIO(tar_bytes)
-        tar = tarfile.open(fileobj=tmp_file, mode="r")
+    try:
         tar = tarfile.open(fileobj=tar_buffer, mode="r")
     except tarfile.TarError as exc:
         raise DockerError(
             f"Failed to read docker save tar for {image_ref!r}",
             str(exc),
         ) from exc
-    # Read the tar bytes from the temporary file to preserve the original
-    # return value while avoiding an extra in-memory copy via BytesIO.
-    tmp_file.seek(0)
-    tar_bytes = tmp_file.read()
-
 
     # Parse manifest.json from the Docker save tar
     try:

--- a/src/regshape/libs/docker/operations.py
+++ b/src/regshape/libs/docker/operations.py
@@ -512,7 +512,7 @@ def push_image(
         registry, repo, reference = parse_image_ref(dest)
 
         config = TransportConfig(
-            base_url=f"{'http' if insecure else 'https'}://{registry}",
+            registry=registry,
             insecure=insecure,
         )
         client = RegistryClient(config)

--- a/src/regshape/libs/docker/operations.py
+++ b/src/regshape/libs/docker/operations.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+
+"""
+:mod:`regshape.libs.docker.operations` - Docker Desktop integration operations
+===============================================================================
+
+.. module:: regshape.libs.docker.operations
+   :platform: Unix, Windows
+   :synopsis: Functions for listing local Docker images, exporting them as OCI
+              Image Layouts, and pushing them to remote OCI registries. Uses the
+              Docker Engine API via the ``docker`` Python SDK.
+
+.. moduleauthor:: ToddySM <toddysm@gmail.com>
+"""
+
+import gzip
+import hashlib
+import io
+import json
+import logging
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Union
+
+import docker as docker_sdk
+from docker.errors import APIError, DockerException, ImageNotFound
+
+from regshape.libs.errors import DockerError, LayoutError
+from regshape.libs.layout.operations import (
+    PushResult,
+    add_blob,
+    init_layout,
+    push_layout,
+)
+from regshape.libs.models.descriptor import Descriptor, Platform
+from regshape.libs.models.manifest import ImageIndex, ImageManifest
+from regshape.libs.models.mediatype import (
+    OCI_IMAGE_CONFIG,
+    OCI_IMAGE_INDEX,
+    OCI_IMAGE_LAYER_TAR_GZIP,
+    OCI_IMAGE_MANIFEST,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ===========================================================================
+# Data models
+# ===========================================================================
+
+
+@dataclass
+class DockerImageInfo:
+    """Summary of a local Docker image.
+
+    :param id: Short image ID (sha256 prefix).
+    :param repo_tags: Repository tags (e.g. ``["nginx:latest"]``).
+    :param repo_digests: Repository digests (e.g. ``["nginx@sha256:abc..."]``).
+    :param size: Image size in bytes.
+    :param created: ISO 8601 creation timestamp.
+    :param architecture: CPU architecture (e.g. ``amd64``).
+    :param os: Operating system (e.g. ``linux``).
+    """
+
+    id: str
+    repo_tags: list[str]
+    repo_digests: list[str]
+    size: int
+    created: str
+    architecture: str
+    os: str
+
+
+# ===========================================================================
+# Private helpers
+# ===========================================================================
+
+_GZIP_MAGIC = b"\x1f\x8b"
+
+
+def _get_docker_client() -> docker_sdk.DockerClient:
+    """Create a Docker client from environment; raise DockerError on failure."""
+    try:
+        return docker_sdk.from_env()
+    except DockerException as exc:
+        raise DockerError(
+            "Cannot connect to Docker daemon. Is Docker Desktop running?",
+            str(exc),
+        ) from exc
+
+
+def _compress_gzip(data: bytes) -> bytes:
+    """Gzip-compress *data* with deterministic (zero) mtime."""
+    buf = io.BytesIO()
+    with gzip.GzipFile(fileobj=buf, mode="wb", mtime=0) as fh:
+        fh.write(data)
+    return buf.getvalue()
+
+
+def _is_gzipped(data: bytes) -> bool:
+    """Return True if *data* starts with the gzip magic bytes."""
+    return data[:2] == _GZIP_MAGIC
+
+
+def _ensure_gzip(data: bytes) -> bytes:
+    """Return gzip-compressed *data*; compress if not already gzipped."""
+    if _is_gzipped(data):
+        return data
+    return _compress_gzip(data)
+
+
+def _parse_platform_string(platform_str: str) -> tuple[str, str]:
+    """Parse ``os/architecture`` into ``(os, architecture)``.
+
+    :raises DockerError: If the format is invalid.
+    """
+    parts = platform_str.split("/")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise DockerError(
+            f"Invalid platform format: {platform_str!r}",
+            "expected 'os/architecture' (e.g. 'linux/amd64')",
+        )
+    return parts[0], parts[1]
+
+
+def _extract_docker_save_tar(image_ref: str, client: docker_sdk.DockerClient) -> tuple[dict, tarfile.TarFile, bytes]:
+    """Save a Docker image and extract its tar contents.
+
+    :returns: Tuple of (parsed manifest.json list, TarFile object, raw tar bytes).
+    :raises DockerError: On image-not-found or API errors.
+    """
+    try:
+        image = client.images.get(image_ref)
+    except ImageNotFound as exc:
+        raise DockerError(
+            f"Image {image_ref!r} not found in local Docker store",
+            str(exc),
+        ) from exc
+    except APIError as exc:
+        raise DockerError(
+            f"Docker API error while fetching image {image_ref!r}",
+            str(exc),
+        ) from exc
+
+    try:
+        chunks = []
+        for chunk in image.save(named=True):
+            chunks.append(chunk)
+        tar_bytes = b"".join(chunks)
+    except APIError as exc:
+        raise DockerError(
+            f"Docker API error while saving image {image_ref!r}",
+            str(exc),
+        ) from exc
+
+    tar_buffer = io.BytesIO(tar_bytes)
+    try:
+        tar = tarfile.open(fileobj=tar_buffer, mode="r")
+    except tarfile.TarError as exc:
+        raise DockerError(
+            f"Failed to read docker save tar for {image_ref!r}",
+            str(exc),
+        ) from exc
+
+    # Parse manifest.json from the Docker save tar
+    try:
+        manifest_member = tar.getmember("manifest.json")
+        manifest_fh = tar.extractfile(manifest_member)
+        if manifest_fh is None:
+            raise DockerError(
+                "manifest.json in docker save tar is empty",
+                f"image: {image_ref}",
+            )
+        docker_manifests = json.loads(manifest_fh.read())
+    except (KeyError, json.JSONDecodeError, tarfile.TarError) as exc:
+        raise DockerError(
+            f"Failed to parse manifest.json from docker save tar for {image_ref!r}",
+            str(exc),
+        ) from exc
+
+    return docker_manifests, tar, tar_bytes
+
+
+def _read_tar_member(tar: tarfile.TarFile, member_path: str) -> bytes:
+    """Read a member from a TarFile, raising DockerError on failure."""
+    try:
+        member = tar.getmember(member_path)
+        fh = tar.extractfile(member)
+        if fh is None:
+            raise DockerError(
+                f"Tar member {member_path!r} is not a regular file",
+                "cannot extract",
+            )
+        return fh.read()
+    except (KeyError, tarfile.TarError) as exc:
+        raise DockerError(
+            f"Failed to read {member_path!r} from docker save tar",
+            str(exc),
+        ) from exc
+
+
+def _docker_config_to_oci(config_data: bytes) -> bytes:
+    """Convert a Docker config JSON to OCI Image Config format.
+
+    Strips Docker-proprietary top-level fields while preserving OCI-relevant
+    fields (architecture, os, rootfs, config, history, etc.).
+
+    :param config_data: Raw Docker config JSON bytes.
+    :returns: OCI config JSON bytes.
+    """
+    config = json.loads(config_data)
+
+    # Fields defined by the OCI Image Config spec
+    oci_config: dict = {}
+
+    # Preserve standard OCI fields
+    for key in ("architecture", "os", "os.version", "os.features",
+                "variant", "config", "rootfs", "history", "created", "author"):
+        if key in config:
+            oci_config[key] = config[key]
+
+    return json.dumps(oci_config, indent=2).encode("utf-8")
+
+
+def _build_oci_manifest(
+    config_descriptor: Descriptor,
+    layer_descriptors: list[Descriptor],
+) -> bytes:
+    """Build an OCI Image Manifest JSON from config and layer descriptors.
+
+    :returns: Canonical manifest JSON bytes.
+    """
+    manifest = ImageManifest(
+        schema_version=2,
+        media_type=OCI_IMAGE_MANIFEST,
+        config=config_descriptor,
+        layers=layer_descriptors,
+    )
+    return manifest.to_json().encode("utf-8")
+
+
+def _convert_single_image(
+    layout_path: Path,
+    tar: tarfile.TarFile,
+    docker_manifest_entry: dict,
+) -> tuple[Descriptor, str, str]:
+    """Convert one Docker save manifest entry to OCI blobs in the layout.
+
+    :param layout_path: Root of the initialised OCI layout.
+    :param tar: Open TarFile of the docker save output.
+    :param docker_manifest_entry: One element from the docker save manifest.json.
+    :returns: Tuple of (manifest_descriptor, architecture, os_name).
+    """
+    # 1. Read and convert config
+    config_path = docker_manifest_entry["Config"]
+    raw_config = _read_tar_member(tar, config_path)
+    config_json = json.loads(raw_config)
+    architecture = config_json.get("architecture", "unknown")
+    os_name = config_json.get("os", "unknown")
+
+    oci_config_bytes = _docker_config_to_oci(raw_config)
+    config_digest, config_size = add_blob(layout_path, oci_config_bytes)
+    config_descriptor = Descriptor(
+        media_type=OCI_IMAGE_CONFIG,
+        digest=config_digest,
+        size=config_size,
+    )
+
+    # 2. Process layers
+    layer_descriptors: list[Descriptor] = []
+    for layer_path in docker_manifest_entry.get("Layers", []):
+        layer_data = _read_tar_member(tar, layer_path)
+        compressed = _ensure_gzip(layer_data)
+        layer_digest, layer_size = add_blob(layout_path, compressed)
+        layer_descriptors.append(
+            Descriptor(
+                media_type=OCI_IMAGE_LAYER_TAR_GZIP,
+                digest=layer_digest,
+                size=layer_size,
+            )
+        )
+
+    # 3. Build and write OCI manifest
+    manifest_bytes = _build_oci_manifest(config_descriptor, layer_descriptors)
+    manifest_digest, manifest_size = add_blob(layout_path, manifest_bytes)
+    manifest_descriptor = Descriptor(
+        media_type=OCI_IMAGE_MANIFEST,
+        digest=manifest_digest,
+        size=manifest_size,
+    )
+
+    return manifest_descriptor, architecture, os_name
+
+
+def _write_index_json(layout_path: Path, index: ImageIndex) -> None:
+    """Write an OCI Image Index to layout_path/index.json."""
+    content = json.dumps(json.loads(index.to_json()), indent=2).encode("utf-8")
+    index_file = layout_path / "index.json"
+    index_file.write_bytes(content)
+
+
+# ===========================================================================
+# Public operations
+# ===========================================================================
+
+
+def list_images(name_filter: str | None = None) -> list[DockerImageInfo]:
+    """List images available in the local Docker daemon.
+
+    :param name_filter: Optional substring filter on image repository name.
+    :returns: List of :class:`DockerImageInfo` summaries.
+    :raises DockerError: If the Docker daemon is unreachable or returns an
+        error.
+    """
+    client = _get_docker_client()
+
+    try:
+        images = client.images.list()
+    except APIError as exc:
+        raise DockerError(
+            "Failed to list Docker images",
+            str(exc),
+        ) from exc
+
+    results: list[DockerImageInfo] = []
+    for img in images:
+        attrs = img.attrs or {}
+        repo_tags = img.tags or []
+
+        # Apply name filter
+        if name_filter:
+            if not any(name_filter in tag for tag in repo_tags):
+                continue
+
+        results.append(
+            DockerImageInfo(
+                id=attrs.get("Id", img.id or ""),
+                repo_tags=repo_tags,
+                repo_digests=attrs.get("RepoDigests", []),
+                size=attrs.get("Size", 0),
+                created=attrs.get("Created", ""),
+                architecture=attrs.get("Architecture", "unknown"),
+                os=attrs.get("Os", "unknown"),
+            )
+        )
+
+    return results
+
+
+def export_image(
+    image_ref: str,
+    output_path: Union[str, Path],
+    *,
+    platform: str | None = None,
+) -> None:
+    """Export a Docker image as an OCI Image Layout directory.
+
+    Layers are always gzip-compressed. Multi-platform images are fully
+    supported: when *platform* is ``None`` all variants are exported,
+    otherwise only the matching platform is included.
+
+    :param image_ref: Docker image reference (e.g. ``nginx:latest`` or image ID).
+    :param output_path: Filesystem path for the OCI layout directory.
+    :param platform: Optional platform filter in ``os/architecture`` format.
+    :raises DockerError: On daemon errors, image-not-found, or
+        platform-not-found.
+    :raises LayoutError: On filesystem / layout errors.
+    """
+    output = Path(output_path)
+    client = _get_docker_client()
+
+    # Extract docker save tar
+    docker_manifests, tar, _ = _extract_docker_save_tar(image_ref, client)
+
+    if not docker_manifests:
+        raise DockerError(
+            f"No manifest entries found in docker save output for {image_ref!r}",
+            "manifest.json is empty",
+        )
+
+    # Initialise OCI layout
+    init_layout(output)
+
+    # Determine which manifest entries to process
+    is_multi = len(docker_manifests) > 1
+
+    if platform is not None:
+        filter_os, filter_arch = _parse_platform_string(platform)
+
+    manifest_descriptors: list[Descriptor] = []
+
+    for entry in docker_manifests:
+        # Read config to get platform info
+        config_path = entry["Config"]
+        raw_config = _read_tar_member(tar, config_path)
+        config_json = json.loads(raw_config)
+        img_arch = config_json.get("architecture", "unknown")
+        img_os = config_json.get("os", "unknown")
+
+        # Apply platform filter
+        if platform is not None:
+            if img_os != filter_os or img_arch != filter_arch:
+                continue
+
+        descriptor, architecture, os_name = _convert_single_image(
+            output, tar, entry
+        )
+
+        # Add platform info to the descriptor for multi-platform layouts
+        descriptor = Descriptor(
+            media_type=descriptor.media_type,
+            digest=descriptor.digest,
+            size=descriptor.size,
+            platform=Platform(architecture=architecture, os=os_name),
+        )
+        manifest_descriptors.append(descriptor)
+
+    tar.close()
+
+    if not manifest_descriptors:
+        if platform is not None:
+            # Collect available platforms for the error message
+            available = []
+            for entry in docker_manifests:
+                config_path = entry["Config"]
+                # Re-open tar to read configs (tar was closed)
+                tar_buffer = io.BytesIO()
+                # We need the raw tar bytes — re-extract from docker
+                client2 = _get_docker_client()
+                docker_manifests2, tar2, _ = _extract_docker_save_tar(image_ref, client2)
+                for e2 in docker_manifests2:
+                    c = _read_tar_member(tar2, e2["Config"])
+                    cj = json.loads(c)
+                    available.append(f"{cj.get('os', '?')}/{cj.get('architecture', '?')}")
+                tar2.close()
+                break
+            raise DockerError(
+                f"Platform {platform!r} not available for image {image_ref!r}",
+                f"Available: {', '.join(available)}",
+            )
+        raise DockerError(
+            f"No images found to export for {image_ref!r}",
+            "manifest entries produced no OCI manifests",
+        )
+
+    # Write index.json
+    index = ImageIndex(
+        schema_version=2,
+        media_type=OCI_IMAGE_INDEX,
+        manifests=manifest_descriptors,
+    )
+    _write_index_json(output, index)
+
+    logger.info(
+        "Exported %d manifest(s) to %s",
+        len(manifest_descriptors),
+        output,
+    )
+
+
+def push_image(
+    image_ref: str,
+    dest: str,
+    *,
+    platform: str | None = None,
+    insecure: bool = False,
+    force: bool = False,
+    chunked: bool = False,
+    chunk_size: int = 65536,
+) -> PushResult:
+    """Export a Docker image and push it to a remote OCI registry.
+
+    Creates a temporary OCI layout, then delegates to
+    :func:`~regshape.libs.layout.operations.push_layout`.
+
+    :param image_ref: Docker image reference (e.g. ``nginx:latest``).
+    :param dest: Destination registry reference (``registry/repo[:tag]``).
+    :param platform: Optional platform filter in ``os/architecture`` format.
+    :param insecure: Allow HTTP (no TLS).
+    :param force: Skip blob existence checks.
+    :param chunked: Use chunked upload protocol for blobs.
+    :param chunk_size: Chunk size in bytes for chunked uploads.
+    :returns: :class:`~regshape.libs.layout.operations.PushResult`.
+    :raises DockerError: On daemon errors.
+    :raises LayoutError: On layout errors.
+    """
+    from regshape.libs.refs import parse_image_ref
+    from regshape.libs.transport.client import RegistryClient, TransportConfig
+
+    tmp_dir = tempfile.mkdtemp(prefix="regshape-docker-")
+    tmp_layout = Path(tmp_dir) / "layout"
+
+    try:
+        export_image(image_ref, tmp_layout, platform=platform)
+
+        registry, repo, reference = parse_image_ref(dest)
+
+        config = TransportConfig(
+            base_url=f"{'http' if insecure else 'https'}://{registry}",
+            insecure=insecure,
+        )
+        client = RegistryClient(config)
+
+        result = push_layout(
+            layout_path=tmp_layout,
+            client=client,
+            repo=repo,
+            tag_override=reference,
+            force=force,
+            chunked=chunked,
+            chunk_size=chunk_size,
+        )
+        return result
+    finally:
+        # Clean up temp directory
+        import shutil
+        shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/src/regshape/libs/docker/operations.py
+++ b/src/regshape/libs/docker/operations.py
@@ -18,6 +18,7 @@ import hashlib
 import io
 import json
 import logging
+import os
 import tarfile
 import tempfile
 from dataclasses import dataclass
@@ -303,7 +304,15 @@ def _write_index_json(layout_path: Path, index: ImageIndex) -> None:
     """Write an OCI Image Index to layout_path/index.json."""
     content = json.dumps(json.loads(index.to_json()), indent=2).encode("utf-8")
     index_file = layout_path / "index.json"
-    index_file.write_bytes(content)
+
+    # Write atomically via a temporary file then replace.
+    with tempfile.NamedTemporaryFile(
+        mode="wb", dir=layout_path, delete=False
+    ) as tmp_file:
+        tmp_file.write(content)
+        tmp_path = Path(tmp_file.name)
+
+    os.replace(tmp_path, index_file)
 
 
 # ===========================================================================

--- a/src/regshape/libs/docker/operations.py
+++ b/src/regshape/libs/docker/operations.py
@@ -145,25 +145,31 @@ def _extract_docker_save_tar(image_ref: str, client: docker_sdk.DockerClient) ->
             str(exc),
         ) from exc
 
-    try:
+        # Stream the docker save output into a temporary file to avoid
+        # accumulating the entire tar archive in memory via a chunk list.
+        tmp_file = tempfile.SpooledTemporaryFile()
         chunks = []
-        for chunk in image.save(named=True):
-            chunks.append(chunk)
+            tmp_file.write(chunk)
+        tmp_file.seek(0)
         tar_bytes = b"".join(chunks)
     except APIError as exc:
         raise DockerError(
             f"Docker API error while saving image {image_ref!r}",
             str(exc),
         ) from exc
-
     tar_buffer = io.BytesIO(tar_bytes)
-    try:
+        tar = tarfile.open(fileobj=tmp_file, mode="r")
         tar = tarfile.open(fileobj=tar_buffer, mode="r")
     except tarfile.TarError as exc:
         raise DockerError(
             f"Failed to read docker save tar for {image_ref!r}",
             str(exc),
         ) from exc
+    # Read the tar bytes from the temporary file to preserve the original
+    # return value while avoiding an extra in-memory copy via BytesIO.
+    tmp_file.seek(0)
+    tar_bytes = tmp_file.read()
+
 
     # Parse manifest.json from the Docker save tar
     try:

--- a/src/regshape/libs/docker/operations.py
+++ b/src/regshape/libs/docker/operations.py
@@ -256,7 +256,12 @@ def _convert_single_image(
     # 1. Read and convert config
     config_path = docker_manifest_entry["Config"]
     raw_config = _read_tar_member(tar, config_path)
-    config_json = json.loads(raw_config)
+    try:
+        config_json = json.loads(raw_config)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise DockerError(
+            f"Failed to parse Docker image config '{config_path}' as JSON"
+        ) from exc
     architecture = config_json.get("architecture", "unknown")
     os_name = config_json.get("os", "unknown")
 

--- a/src/regshape/libs/docker/operations.py
+++ b/src/regshape/libs/docker/operations.py
@@ -133,11 +133,11 @@ def _extract_docker_save_tar(image_ref: str, client: docker_sdk.DockerClient) ->
     """
     try:
         image = client.images.get(image_ref)
-    except ImageNotFound as exc:
+    except ImageNotFound:
         raise DockerError(
             f"Image {image_ref!r} not found in local Docker store",
-            str(exc),
-        ) from exc
+            "run 'regshape docker list' to see available images",
+        )
     except APIError as exc:
         raise DockerError(
             f"Docker API error while fetching image {image_ref!r}",
@@ -369,6 +369,20 @@ def export_image(
     :raises LayoutError: On filesystem / layout errors.
     """
     output = Path(output_path)
+
+    # Validate output path before talking to Docker
+    if output.exists():
+        if (output / "oci-layout").exists():
+            raise LayoutError(
+                f"{output} is already an OCI Image Layout",
+                "oci-layout file already exists; use a new directory or remove the existing layout",
+            )
+        if any(output.iterdir()):
+            raise LayoutError(
+                f"Output directory {output} already exists and is not empty",
+                "use a new directory or remove the existing contents",
+            )
+
     client = _get_docker_client()
 
     # Extract docker save tar

--- a/src/regshape/libs/docker/operations.py
+++ b/src/regshape/libs/docker/operations.py
@@ -221,7 +221,7 @@ def _docker_config_to_oci(config_data: bytes) -> bytes:
         if key in config:
             oci_config[key] = config[key]
 
-    return json.dumps(oci_config, indent=2).encode("utf-8")
+    return json.dumps(oci_config, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
 
 def _build_oci_manifest(

--- a/src/regshape/libs/errors.py
+++ b/src/regshape/libs/errors.py
@@ -84,3 +84,10 @@ class LayoutError(RegShapeError):
     Error caused by an invalid or inconsistent OCI Image Layout on disk.
     """
     pass
+
+
+class DockerError(RegShapeError):
+    """
+    Error caused by a Docker daemon interaction failure.
+    """
+    pass

--- a/src/regshape/tests/test_docker_cli.py
+++ b/src/regshape/tests/test_docker_cli.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+
+"""Tests for :mod:`regshape.cli.docker`.
+
+Uses the Click test runner to exercise all docker CLI commands.
+Library functions are mocked to avoid requiring a running Docker daemon.
+"""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+from unittest.mock import MagicMock, patch
+
+from regshape.cli.main import regshape
+from regshape.libs.docker.operations import DockerImageInfo
+from regshape.libs.errors import DockerError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _runner():
+    return CliRunner()
+
+
+def _sample_images():
+    return [
+        DockerImageInfo(
+            id="sha256:a8758716bb6a92c62e8e2f5a463d53a31ef3a32e12cd1a41ee1030e5560268b0",
+            repo_tags=["nginx:latest", "nginx:1.25"],
+            repo_digests=["nginx@sha256:aaa"],
+            size=196083713,
+            created="2025-12-01T10:30:00Z",
+            architecture="amd64",
+            os="linux",
+        ),
+        DockerImageInfo(
+            id="sha256:b5d5cef26b2a3e9f2dfc4e1b0e5d1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8",
+            repo_tags=["python:3.12"],
+            repo_digests=[],
+            size=1073741824,
+            created="2025-11-15T08:00:00Z",
+            architecture="amd64",
+            os="linux",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# docker list
+# ---------------------------------------------------------------------------
+
+
+class TestDockerListCLI:
+    @patch("regshape.cli.docker.list_images")
+    def test_list_plain_output(self, mock_list):
+        mock_list.return_value = _sample_images()
+        result = _runner().invoke(regshape, ["docker", "list"])
+        assert result.exit_code == 0, result.output
+        assert "nginx" in result.output
+        assert "python" in result.output
+        assert "REPOSITORY" in result.output
+
+    @patch("regshape.cli.docker.list_images")
+    def test_list_json_output(self, mock_list):
+        mock_list.return_value = _sample_images()
+        result = _runner().invoke(regshape, ["docker", "list", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert len(data) == 2
+        assert data[0]["repo_tags"] == ["nginx:latest", "nginx:1.25"]
+        assert data[1]["repo_tags"] == ["python:3.12"]
+
+    @patch("regshape.cli.docker.list_images")
+    def test_list_with_filter(self, mock_list):
+        mock_list.return_value = [_sample_images()[0]]
+        result = _runner().invoke(regshape, ["docker", "list", "--filter", "nginx"])
+        assert result.exit_code == 0, result.output
+        mock_list.assert_called_once_with(name_filter="nginx")
+
+    @patch("regshape.cli.docker.list_images")
+    def test_list_empty(self, mock_list):
+        mock_list.return_value = []
+        result = _runner().invoke(regshape, ["docker", "list"])
+        assert result.exit_code == 0, result.output
+        assert "No images found" in result.output
+
+    @patch("regshape.cli.docker.list_images")
+    def test_list_docker_error(self, mock_list):
+        mock_list.side_effect = DockerError(
+            "Cannot connect to Docker daemon. Is Docker Desktop running?",
+            "connection refused",
+        )
+        result = _runner().invoke(regshape, ["docker", "list"])
+        assert result.exit_code != 0
+        assert "Error" in result.output
+
+
+# ---------------------------------------------------------------------------
+# docker export
+# ---------------------------------------------------------------------------
+
+
+class TestDockerExportCLI:
+    @patch("regshape.cli.docker.export_image")
+    def test_export_plain_output(self, mock_export, tmp_path):
+        output = str(tmp_path / "layout")
+        result = _runner().invoke(
+            regshape, ["docker", "export", "--image", "nginx:latest", "--output", output]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Exported" in result.output
+        assert "nginx:latest" in result.output
+        mock_export.assert_called_once_with("nginx:latest", output, platform=None)
+
+    @patch("regshape.cli.docker.export_image")
+    def test_export_json_output(self, mock_export, tmp_path):
+        output = str(tmp_path / "layout")
+        result = _runner().invoke(
+            regshape,
+            ["docker", "export", "--image", "nginx:latest", "--output", output, "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["image"] == "nginx:latest"
+        assert data["output"] == output
+
+    @patch("regshape.cli.docker.export_image")
+    def test_export_with_platform(self, mock_export, tmp_path):
+        output = str(tmp_path / "layout")
+        result = _runner().invoke(
+            regshape,
+            ["docker", "export", "--image", "nginx:latest", "--output", output,
+             "--platform", "linux/amd64"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "linux/amd64" in result.output
+        mock_export.assert_called_once_with(
+            "nginx:latest", output, platform="linux/amd64"
+        )
+
+    @patch("regshape.cli.docker.export_image")
+    def test_export_docker_error(self, mock_export, tmp_path):
+        mock_export.side_effect = DockerError(
+            "Image 'nope' not found in local Docker store",
+            "not found",
+        )
+        output = str(tmp_path / "layout")
+        result = _runner().invoke(
+            regshape, ["docker", "export", "--image", "nope", "--output", output]
+        )
+        assert result.exit_code != 0
+        assert "Error" in result.output
+
+    def test_export_missing_required_options(self):
+        result = _runner().invoke(regshape, ["docker", "export"])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# docker push
+# ---------------------------------------------------------------------------
+
+
+class TestDockerPushCLI:
+    @patch("regshape.cli.docker.push_image")
+    def test_push_plain_output(self, mock_push):
+        mock_result = MagicMock()
+        mock_result.manifests = [
+            MagicMock(blobs=[
+                MagicMock(uploaded=True),
+                MagicMock(uploaded=False),
+            ])
+        ]
+        mock_push.return_value = mock_result
+
+        result = _runner().invoke(
+            regshape,
+            ["docker", "push", "--image", "nginx:latest",
+             "--dest", "registry.io/myrepo/nginx:v1"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Pushed" in result.output
+        assert "1 manifest(s)" in result.output
+        assert "1 blob(s) uploaded" in result.output
+        assert "1 blob(s) skipped" in result.output
+
+    @patch("regshape.cli.docker.push_image")
+    def test_push_json_output(self, mock_push):
+        mock_result = MagicMock()
+        mock_result.manifests = [
+            MagicMock(blobs=[
+                MagicMock(uploaded=True),
+                MagicMock(uploaded=True),
+            ])
+        ]
+        mock_push.return_value = mock_result
+
+        result = _runner().invoke(
+            regshape,
+            ["docker", "push", "--image", "nginx:latest",
+             "--dest", "registry.io/myrepo/nginx:v1", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["image"] == "nginx:latest"
+        assert data["destination"] == "registry.io/myrepo/nginx:v1"
+        assert data["manifests_pushed"] == 1
+        assert data["blobs_uploaded"] == 2
+
+    @patch("regshape.cli.docker.push_image")
+    def test_push_with_platform(self, mock_push):
+        mock_result = MagicMock()
+        mock_result.manifests = []
+        mock_push.return_value = mock_result
+
+        result = _runner().invoke(
+            regshape,
+            ["docker", "push", "--image", "nginx:latest",
+             "--dest", "registry.io/myrepo/nginx:v1",
+             "--platform", "linux/arm64"],
+        )
+        assert result.exit_code == 0, result.output
+
+    @patch("regshape.cli.docker.push_image")
+    def test_push_docker_error(self, mock_push):
+        mock_push.side_effect = DockerError(
+            "Cannot connect to Docker daemon. Is Docker Desktop running?",
+            "connection refused",
+        )
+        result = _runner().invoke(
+            regshape,
+            ["docker", "push", "--image", "nginx:latest",
+             "--dest", "registry.io/myrepo/nginx:v1"],
+        )
+        assert result.exit_code != 0
+        assert "Error" in result.output
+
+    @patch("regshape.cli.docker.push_image")
+    def test_push_with_force_and_chunked(self, mock_push):
+        mock_result = MagicMock()
+        mock_result.manifests = []
+        mock_push.return_value = mock_result
+
+        result = _runner().invoke(
+            regshape,
+            ["docker", "push", "--image", "nginx:latest",
+             "--dest", "registry.io/myrepo/nginx:v1",
+             "--force", "--chunked", "--chunk-size", "131072"],
+        )
+        assert result.exit_code == 0, result.output
+        mock_push.assert_called_once()
+        call_kwargs = mock_push.call_args
+        assert call_kwargs[1]["force"] is True
+        assert call_kwargs[1]["chunked"] is True
+        assert call_kwargs[1]["chunk_size"] == 131072
+
+    def test_push_missing_required_options(self):
+        result = _runner().invoke(regshape, ["docker", "push"])
+        assert result.exit_code != 0

--- a/src/regshape/tests/test_docker_operations.py
+++ b/src/regshape/tests/test_docker_operations.py
@@ -10,6 +10,7 @@ import hashlib
 import io
 import json
 import tarfile
+import tempfile
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -18,6 +19,7 @@ from regshape.libs.docker.operations import (
     DockerImageInfo,
     export_image,
     list_images,
+    push_image,
     _compress_gzip,
     _docker_config_to_oci,
     _ensure_gzip,
@@ -462,3 +464,112 @@ class TestExportImage:
             layer_bytes = (output / "blobs" / "sha256" / layer_hex).read_bytes()
             # Verify gzip magic bytes
             assert layer_bytes[:2] == b"\x1f\x8b", "Layer should be gzip-compressed"
+
+
+# ---------------------------------------------------------------------------
+# Tests: push_image
+# ---------------------------------------------------------------------------
+
+
+class TestPushImage:
+    @patch("regshape.libs.docker.operations.push_layout")
+    @patch("regshape.libs.docker.operations.export_image")
+    def test_push_calls_export_and_push_layout(self, mock_export, mock_push_layout):
+        mock_push_result = MagicMock()
+        mock_push_layout.return_value = mock_push_result
+
+        result = push_image(
+            "nginx:latest",
+            "registry.io/myrepo/nginx:v1",
+            insecure=False,
+            force=True,
+            chunked=True,
+            chunk_size=131072,
+        )
+
+        # export_image was called with a temp layout path
+        mock_export.assert_called_once()
+        call_args = mock_export.call_args
+        assert call_args[0][0] == "nginx:latest"
+        assert call_args[1]["platform"] is None
+
+        # push_layout was called with correct params
+        mock_push_layout.assert_called_once()
+        push_kwargs = mock_push_layout.call_args[1]
+        assert push_kwargs["repo"] == "myrepo/nginx"
+        assert push_kwargs["tag_override"] == "v1"
+        assert push_kwargs["force"] is True
+        assert push_kwargs["chunked"] is True
+        assert push_kwargs["chunk_size"] == 131072
+
+        assert result is mock_push_result
+
+    @patch("regshape.libs.docker.operations.push_layout")
+    @patch("regshape.libs.docker.operations.export_image")
+    def test_push_passes_platform_to_export(self, mock_export, mock_push_layout):
+        mock_push_layout.return_value = MagicMock()
+
+        push_image(
+            "nginx:latest",
+            "registry.io/myrepo/nginx:v1",
+            platform="linux/arm64",
+        )
+
+        call_kwargs = mock_export.call_args[1]
+        assert call_kwargs["platform"] == "linux/arm64"
+
+    @patch("regshape.libs.docker.operations.push_layout")
+    @patch("regshape.libs.docker.operations.export_image")
+    def test_push_uses_insecure_for_transport_config(self, mock_export, mock_push_layout):
+        mock_push_layout.return_value = MagicMock()
+
+        push_image(
+            "nginx:latest",
+            "registry.io/myrepo/nginx:v1",
+            insecure=True,
+        )
+
+        push_kwargs = mock_push_layout.call_args[1]
+        client = push_kwargs["client"]
+        assert client.config.insecure is True
+
+    @patch("regshape.libs.docker.operations.push_layout")
+    @patch("regshape.libs.docker.operations.export_image")
+    def test_push_cleans_up_temp_dir_on_success(self, mock_export, mock_push_layout, tmp_path):
+        import os
+        mock_push_layout.return_value = MagicMock()
+
+        created_dirs = []
+        original_mkdtemp = tempfile.mkdtemp
+
+        def tracking_mkdtemp(**kwargs):
+            d = original_mkdtemp(**kwargs)
+            created_dirs.append(d)
+            return d
+
+        with patch("regshape.libs.docker.operations.tempfile.mkdtemp", side_effect=tracking_mkdtemp):
+            push_image("nginx:latest", "registry.io/myrepo/nginx:v1")
+
+        assert len(created_dirs) == 1
+        assert not os.path.exists(created_dirs[0])
+
+    @patch("regshape.libs.docker.operations.push_layout")
+    @patch("regshape.libs.docker.operations.export_image")
+    def test_push_cleans_up_temp_dir_on_failure(self, mock_export, mock_push_layout):
+        import os
+        mock_export.side_effect = DockerError("export failed", "test")
+
+        created_dirs = []
+        original_mkdtemp = tempfile.mkdtemp
+
+        def tracking_mkdtemp(**kwargs):
+            d = original_mkdtemp(**kwargs)
+            created_dirs.append(d)
+            return d
+
+        with patch("regshape.libs.docker.operations.tempfile.mkdtemp", side_effect=tracking_mkdtemp):
+            with pytest.raises(DockerError):
+                push_image("nginx:latest", "registry.io/myrepo/nginx:v1")
+
+        assert len(created_dirs) == 1
+        assert not os.path.exists(created_dirs[0])

--- a/src/regshape/tests/test_docker_operations.py
+++ b/src/regshape/tests/test_docker_operations.py
@@ -399,6 +399,38 @@ class TestExportImage:
         output = tmp_path / "layout"
         with pytest.raises(DockerError, match="not found in local Docker store"):
             export_image("nonexistent:latest", output)
+    def test_export_fails_if_output_is_existing_layout(self, tmp_path):
+        output = tmp_path / "layout"
+        output.mkdir()
+        (output / "oci-layout").write_text('{"imageLayoutVersion": "1.0.0"}')
+
+        with pytest.raises(LayoutError, match="already an OCI Image Layout"):
+            export_image("testimage:latest", output)
+
+    def test_export_fails_if_output_dir_not_empty(self, tmp_path):
+        output = tmp_path / "layout"
+        output.mkdir()
+        (output / "somefile.txt").write_text("hello")
+
+        with pytest.raises(LayoutError, match="not empty"):
+            export_image("testimage:latest", output)
+    @patch("regshape.libs.docker.operations._get_docker_client")
+    def test_export_fails_if_output_is_existing_layout(self, mock_get_client, tmp_path):
+        output = tmp_path / "layout"
+        output.mkdir()
+        (output / "oci-layout").write_text('{"imageLayoutVersion": "1.0.0"}')
+
+        with pytest.raises(LayoutError, match="already an OCI Image Layout"):
+            export_image("testimage:latest", output)
+
+    @patch("regshape.libs.docker.operations._get_docker_client")
+    def test_export_fails_if_output_dir_not_empty(self, mock_get_client, tmp_path):
+        output = tmp_path / "layout"
+        output.mkdir()
+        (output / "somefile.txt").write_text("hello")
+
+        with pytest.raises(LayoutError, match="not empty"):
+            export_image("testimage:latest", output)
 
     @patch("regshape.libs.docker.operations._get_docker_client")
     def test_export_layers_are_gzip_compressed(self, mock_get_client, tmp_path):

--- a/src/regshape/tests/test_docker_operations.py
+++ b/src/regshape/tests/test_docker_operations.py
@@ -399,7 +399,7 @@ class TestExportImage:
         output = tmp_path / "layout"
         with pytest.raises(DockerError, match="not found in local Docker store"):
             export_image("nonexistent:latest", output)
-    def test_export_fails_if_output_is_existing_layout(self, tmp_path):
+    def test_export_fails_if_output_is_existing_layout_without_docker_mock(self, tmp_path):
         output = tmp_path / "layout"
         output.mkdir()
         (output / "oci-layout").write_text('{"imageLayoutVersion": "1.0.0"}')
@@ -407,7 +407,7 @@ class TestExportImage:
         with pytest.raises(LayoutError, match="already an OCI Image Layout"):
             export_image("testimage:latest", output)
 
-    def test_export_fails_if_output_dir_not_empty(self, tmp_path):
+    def test_export_fails_if_output_dir_not_empty_without_docker_mock(self, tmp_path):
         output = tmp_path / "layout"
         output.mkdir()
         (output / "somefile.txt").write_text("hello")

--- a/src/regshape/tests/test_docker_operations.py
+++ b/src/regshape/tests/test_docker_operations.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+
+"""Tests for :mod:`regshape.libs.docker.operations`.
+
+All Docker daemon interactions are mocked via ``unittest.mock``.
+"""
+
+import gzip
+import hashlib
+import io
+import json
+import tarfile
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from regshape.libs.docker.operations import (
+    DockerImageInfo,
+    export_image,
+    list_images,
+    _compress_gzip,
+    _docker_config_to_oci,
+    _ensure_gzip,
+    _is_gzipped,
+    _parse_platform_string,
+)
+from regshape.libs.errors import DockerError, LayoutError
+from regshape.libs.models.mediatype import (
+    OCI_IMAGE_CONFIG,
+    OCI_IMAGE_INDEX,
+    OCI_IMAGE_LAYER_TAR_GZIP,
+    OCI_IMAGE_MANIFEST,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sha256(content: bytes) -> str:
+    return "sha256:" + hashlib.sha256(content).hexdigest()
+
+
+def _make_docker_save_tar(manifests_json: list[dict], configs: dict, layers: dict) -> bytes:
+    """Build a fake docker-save tar archive in-memory.
+
+    :param manifests_json: The manifest.json content (list of dicts).
+    :param configs: Mapping of config_path -> config JSON bytes.
+    :param layers: Mapping of layer_path -> layer bytes.
+    :returns: Raw tar bytes.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        # manifest.json
+        mj_bytes = json.dumps(manifests_json).encode("utf-8")
+        info = tarfile.TarInfo(name="manifest.json")
+        info.size = len(mj_bytes)
+        tar.addfile(info, io.BytesIO(mj_bytes))
+
+        # configs
+        for path, content in configs.items():
+            info = tarfile.TarInfo(name=path)
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+
+        # layers
+        for path, content in layers.items():
+            info = tarfile.TarInfo(name=path)
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+
+    return buf.getvalue()
+
+
+def _make_docker_config(architecture: str = "amd64", os_name: str = "linux") -> bytes:
+    """Build a minimal Docker config JSON."""
+    return json.dumps({
+        "architecture": architecture,
+        "os": os_name,
+        "rootfs": {"type": "layers", "diff_ids": ["sha256:abc"]},
+        "config": {"Env": ["PATH=/usr/bin"]},
+        "history": [{"created": "2025-01-01T00:00:00Z"}],
+    }).encode("utf-8")
+
+
+def _make_single_platform_tar(architecture: str = "amd64", os_name: str = "linux") -> bytes:
+    """Build a Docker save tar with a single platform image."""
+    config = _make_docker_config(architecture, os_name)
+    config_hash = hashlib.sha256(config).hexdigest()
+    config_path = f"{config_hash}.json"
+    layer_data = b"fake layer data"
+    layer_path = "abc123/layer.tar"
+
+    manifest = [{
+        "Config": config_path,
+        "RepoTags": ["testimage:latest"],
+        "Layers": [layer_path],
+    }]
+
+    return _make_docker_save_tar(manifest, {config_path: config}, {layer_path: layer_data})
+
+
+def _make_multi_platform_tar() -> bytes:
+    """Build a Docker save tar with two platform variants."""
+    config_amd64 = _make_docker_config("amd64", "linux")
+    config_arm64 = _make_docker_config("arm64", "linux")
+
+    hash_amd64 = hashlib.sha256(config_amd64).hexdigest()
+    hash_arm64 = hashlib.sha256(config_arm64).hexdigest()
+
+    layer_amd64 = b"amd64 layer"
+    layer_arm64 = b"arm64 layer"
+
+    manifests = [
+        {
+            "Config": f"{hash_amd64}.json",
+            "RepoTags": ["testimage:latest"],
+            "Layers": ["amd64/layer.tar"],
+        },
+        {
+            "Config": f"{hash_arm64}.json",
+            "RepoTags": ["testimage:latest"],
+            "Layers": ["arm64/layer.tar"],
+        },
+    ]
+
+    configs = {
+        f"{hash_amd64}.json": config_amd64,
+        f"{hash_arm64}.json": config_arm64,
+    }
+    layers = {
+        "amd64/layer.tar": layer_amd64,
+        "arm64/layer.tar": layer_arm64,
+    }
+
+    return _make_docker_save_tar(manifests, configs, layers)
+
+
+def _mock_image_save(tar_bytes: bytes):
+    """Return a generator that yields the tar bytes in chunks (simulating image.save())."""
+    def save(named=True):
+        # Yield in one chunk for simplicity
+        yield tar_bytes
+    return save
+
+
+# ---------------------------------------------------------------------------
+# Tests: helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_compress_gzip(self):
+        data = b"hello world"
+        compressed = _compress_gzip(data)
+        assert compressed[:2] == b"\x1f\x8b"
+        decompressed = gzip.decompress(compressed)
+        assert decompressed == data
+
+    def test_is_gzipped_true(self):
+        compressed = _compress_gzip(b"test")
+        assert _is_gzipped(compressed) is True
+
+    def test_is_gzipped_false(self):
+        assert _is_gzipped(b"plain data") is False
+
+    def test_ensure_gzip_compresses_uncompressed(self):
+        data = b"uncompressed"
+        result = _ensure_gzip(data)
+        assert _is_gzipped(result)
+        assert gzip.decompress(result) == data
+
+    def test_ensure_gzip_passes_through_gzipped(self):
+        compressed = _compress_gzip(b"already compressed")
+        result = _ensure_gzip(compressed)
+        assert result == compressed
+
+    def test_parse_platform_string_valid(self):
+        os_name, arch = _parse_platform_string("linux/amd64")
+        assert os_name == "linux"
+        assert arch == "amd64"
+
+    def test_parse_platform_string_invalid(self):
+        with pytest.raises(DockerError, match="Invalid platform format"):
+            _parse_platform_string("invalid")
+
+    def test_parse_platform_string_empty_parts(self):
+        with pytest.raises(DockerError, match="Invalid platform format"):
+            _parse_platform_string("/")
+
+
+class TestDockerConfigToOci:
+    def test_preserves_oci_fields(self):
+        docker_config = json.dumps({
+            "architecture": "amd64",
+            "os": "linux",
+            "rootfs": {"type": "layers", "diff_ids": []},
+            "config": {"Env": ["PATH=/usr/bin"]},
+            "history": [],
+            "created": "2025-01-01T00:00:00Z",
+        }).encode("utf-8")
+
+        oci_bytes = _docker_config_to_oci(docker_config)
+        oci = json.loads(oci_bytes)
+
+        assert oci["architecture"] == "amd64"
+        assert oci["os"] == "linux"
+        assert "rootfs" in oci
+        assert "config" in oci
+        assert "history" in oci
+        assert "created" in oci
+
+    def test_strips_docker_proprietary_fields(self):
+        docker_config = json.dumps({
+            "architecture": "amd64",
+            "os": "linux",
+            "rootfs": {"type": "layers", "diff_ids": []},
+            "container": "abcdef123456",
+            "docker_version": "20.10.0",
+            "container_config": {"Hostname": "abc"},
+        }).encode("utf-8")
+
+        oci_bytes = _docker_config_to_oci(docker_config)
+        oci = json.loads(oci_bytes)
+
+        assert "container" not in oci
+        assert "docker_version" not in oci
+        assert "container_config" not in oci
+
+
+# ---------------------------------------------------------------------------
+# Tests: list_images
+# ---------------------------------------------------------------------------
+
+
+class TestListImages:
+    @patch("regshape.libs.docker.operations.docker_sdk")
+    def test_list_images_returns_info(self, mock_sdk):
+        mock_client = MagicMock()
+        mock_sdk.from_env.return_value = mock_client
+
+        mock_image = MagicMock()
+        mock_image.tags = ["nginx:latest"]
+        mock_image.id = "sha256:abc123"
+        mock_image.attrs = {
+            "Id": "sha256:abc123def456",
+            "RepoDigests": ["nginx@sha256:aaa"],
+            "Size": 196083713,
+            "Created": "2025-12-01T10:30:00Z",
+            "Architecture": "amd64",
+            "Os": "linux",
+        }
+        mock_client.images.list.return_value = [mock_image]
+
+        result = list_images()
+
+        assert len(result) == 1
+        assert result[0].id == "sha256:abc123def456"
+        assert result[0].repo_tags == ["nginx:latest"]
+        assert result[0].size == 196083713
+        assert result[0].architecture == "amd64"
+
+    @patch("regshape.libs.docker.operations.docker_sdk")
+    def test_list_images_with_filter(self, mock_sdk):
+        mock_client = MagicMock()
+        mock_sdk.from_env.return_value = mock_client
+
+        img1 = MagicMock()
+        img1.tags = ["nginx:latest"]
+        img1.id = "sha256:aaa"
+        img1.attrs = {"Id": "sha256:aaa", "RepoDigests": [], "Size": 100,
+                       "Created": "", "Architecture": "amd64", "Os": "linux"}
+
+        img2 = MagicMock()
+        img2.tags = ["python:3.12"]
+        img2.id = "sha256:bbb"
+        img2.attrs = {"Id": "sha256:bbb", "RepoDigests": [], "Size": 200,
+                       "Created": "", "Architecture": "amd64", "Os": "linux"}
+
+        mock_client.images.list.return_value = [img1, img2]
+
+        result = list_images(name_filter="nginx")
+        assert len(result) == 1
+        assert result[0].repo_tags == ["nginx:latest"]
+
+    @patch("regshape.libs.docker.operations.docker_sdk")
+    def test_list_images_daemon_not_running(self, mock_sdk):
+        from docker.errors import DockerException
+        mock_sdk.from_env.side_effect = DockerException("connection refused")
+
+        with pytest.raises(DockerError, match="Cannot connect to Docker daemon"):
+            list_images()
+
+
+# ---------------------------------------------------------------------------
+# Tests: export_image
+# ---------------------------------------------------------------------------
+
+
+class TestExportImage:
+    @patch("regshape.libs.docker.operations._get_docker_client")
+    def test_export_single_platform(self, mock_get_client, tmp_path):
+        tar_bytes = _make_single_platform_tar()
+        mock_client = MagicMock()
+        mock_image = MagicMock()
+        mock_image.save = _mock_image_save(tar_bytes)
+        mock_client.images.get.return_value = mock_image
+        mock_get_client.return_value = mock_client
+
+        output = tmp_path / "layout"
+        export_image("testimage:latest", output)
+
+        # Verify OCI layout structure
+        assert (output / "oci-layout").exists()
+        assert (output / "index.json").exists()
+        assert (output / "blobs" / "sha256").is_dir()
+
+        # Verify index.json
+        index = json.loads((output / "index.json").read_text())
+        assert index["schemaVersion"] == 2
+        assert index["mediaType"] == OCI_IMAGE_INDEX
+        assert len(index["manifests"]) == 1
+
+        manifest_desc = index["manifests"][0]
+        assert manifest_desc["mediaType"] == OCI_IMAGE_MANIFEST
+        assert manifest_desc["platform"]["architecture"] == "amd64"
+        assert manifest_desc["platform"]["os"] == "linux"
+
+        # Verify manifest blob exists and is valid
+        digest = manifest_desc["digest"]
+        _, hex_digest = digest.split(":", 1)
+        manifest_blob = output / "blobs" / "sha256" / hex_digest
+        assert manifest_blob.exists()
+        manifest_data = json.loads(manifest_blob.read_text())
+        assert manifest_data["mediaType"] == OCI_IMAGE_MANIFEST
+        assert manifest_data["config"]["mediaType"] == OCI_IMAGE_CONFIG
+        assert len(manifest_data["layers"]) == 1
+        assert manifest_data["layers"][0]["mediaType"] == OCI_IMAGE_LAYER_TAR_GZIP
+
+    @patch("regshape.libs.docker.operations._get_docker_client")
+    def test_export_multi_platform_all(self, mock_get_client, tmp_path):
+        tar_bytes = _make_multi_platform_tar()
+        mock_client = MagicMock()
+        mock_image = MagicMock()
+        mock_image.save = _mock_image_save(tar_bytes)
+        mock_client.images.get.return_value = mock_image
+        mock_get_client.return_value = mock_client
+
+        output = tmp_path / "layout"
+        export_image("testimage:latest", output)
+
+        index = json.loads((output / "index.json").read_text())
+        assert len(index["manifests"]) == 2
+
+        platforms = {
+            (m["platform"]["os"], m["platform"]["architecture"])
+            for m in index["manifests"]
+        }
+        assert ("linux", "amd64") in platforms
+        assert ("linux", "arm64") in platforms
+
+    @patch("regshape.libs.docker.operations._get_docker_client")
+    def test_export_multi_platform_filtered(self, mock_get_client, tmp_path):
+        tar_bytes = _make_multi_platform_tar()
+        mock_client = MagicMock()
+        mock_image = MagicMock()
+        mock_image.save = _mock_image_save(tar_bytes)
+        mock_client.images.get.return_value = mock_image
+        mock_get_client.return_value = mock_client
+
+        output = tmp_path / "layout"
+        export_image("testimage:latest", output, platform="linux/arm64")
+
+        index = json.loads((output / "index.json").read_text())
+        assert len(index["manifests"]) == 1
+        assert index["manifests"][0]["platform"]["architecture"] == "arm64"
+
+    @patch("regshape.libs.docker.operations._get_docker_client")
+    def test_export_platform_not_found(self, mock_get_client, tmp_path):
+        tar_bytes = _make_single_platform_tar("amd64", "linux")
+        mock_client = MagicMock()
+        mock_image = MagicMock()
+        mock_image.save = _mock_image_save(tar_bytes)
+        mock_client.images.get.return_value = mock_image
+        mock_get_client.return_value = mock_client
+
+        output = tmp_path / "layout"
+        with pytest.raises(DockerError, match="Platform.*not available"):
+            export_image("testimage:latest", output, platform="linux/arm64")
+
+    @patch("regshape.libs.docker.operations._get_docker_client")
+    def test_export_image_not_found(self, mock_get_client, tmp_path):
+        from docker.errors import ImageNotFound
+        mock_client = MagicMock()
+        mock_client.images.get.side_effect = ImageNotFound("not found")
+        mock_get_client.return_value = mock_client
+
+        output = tmp_path / "layout"
+        with pytest.raises(DockerError, match="not found in local Docker store"):
+            export_image("nonexistent:latest", output)
+
+    @patch("regshape.libs.docker.operations._get_docker_client")
+    def test_export_layers_are_gzip_compressed(self, mock_get_client, tmp_path):
+        tar_bytes = _make_single_platform_tar()
+        mock_client = MagicMock()
+        mock_image = MagicMock()
+        mock_image.save = _mock_image_save(tar_bytes)
+        mock_client.images.get.return_value = mock_image
+        mock_get_client.return_value = mock_client
+
+        output = tmp_path / "layout"
+        export_image("testimage:latest", output)
+
+        # Find layer blobs and verify they are gzip-compressed
+        index = json.loads((output / "index.json").read_text())
+        manifest_digest = index["manifests"][0]["digest"]
+        _, manifest_hex = manifest_digest.split(":", 1)
+        manifest_data = json.loads(
+            (output / "blobs" / "sha256" / manifest_hex).read_text()
+        )
+
+        for layer in manifest_data["layers"]:
+            _, layer_hex = layer["digest"].split(":", 1)
+            layer_bytes = (output / "blobs" / "sha256" / layer_hex).read_bytes()
+            # Verify gzip magic bytes
+            assert layer_bytes[:2] == b"\x1f\x8b", "Layer should be gzip-compressed"

--- a/src/regshape/tests/test_docker_operations.py
+++ b/src/regshape/tests/test_docker_operations.py
@@ -414,8 +414,11 @@ class TestExportImage:
 
         with pytest.raises(LayoutError, match="not empty"):
             export_image("testimage:latest", output)
+
     @patch("regshape.libs.docker.operations._get_docker_client")
-    def test_export_fails_if_output_is_existing_layout(self, mock_get_client, tmp_path):
+    def test_export_fails_if_output_is_existing_layout_with_mocked_client(
+        self, mock_get_client, tmp_path
+    ):
         output = tmp_path / "layout"
         output.mkdir()
         (output / "oci-layout").write_text('{"imageLayoutVersion": "1.0.0"}')
@@ -424,7 +427,9 @@ class TestExportImage:
             export_image("testimage:latest", output)
 
     @patch("regshape.libs.docker.operations._get_docker_client")
-    def test_export_fails_if_output_dir_not_empty(self, mock_get_client, tmp_path):
+    def test_export_fails_if_output_dir_not_empty_with_mocked_client(
+        self, mock_get_client, tmp_path
+    ):
         output = tmp_path / "layout"
         output.mkdir()
         (output / "somefile.txt").write_text("hello")


### PR DESCRIPTION
## Summary

Implements issue #41: Docker Desktop integration for listing, exporting, and pushing local Docker images as OCI Image Layouts.

## Changes

### New files
- **`src/regshape/libs/docker/__init__.py`** — Package exports
- **`src/regshape/libs/docker/operations.py`** — Core library operations:
  - `list_images()` — enumerate images in the local Docker daemon with optional name filtering
  - `export_image()` — export a Docker image as a valid OCI Image Layout directory with gzip-compressed layers; supports multi-platform images with `--platform` filtering
  - `push_image()` — export and push a Docker image to a remote OCI registry, reusing existing `push_layout()` infrastructure
- **`src/regshape/cli/docker.py`** — Click CLI command group with three subcommands:
  - `regshape docker list` — list local Docker images (table or JSON output)
  - `regshape docker export` — export to OCI layout on disk
  - `regshape docker push` — push directly to a remote registry
- **`src/regshape/tests/test_docker_operations.py`** — 23 unit tests for library operations
- **`src/regshape/tests/test_docker_cli.py`** — 14 CLI tests using Click's CliRunner
- **`specs/docker/docker-desktop-integration.md`** — Design specification

### Modified files
- **`src/regshape/cli/main.py`** — Wired `docker` command group
- **`src/regshape/libs/errors.py`** — Added `DockerError` exception class
- **`requirements.txt`** — Added `docker>=7.0.0` dependency

## Key design decisions

- **Multi-platform support**: Docker buildx multi-arch images are fully supported. When `--platform` is omitted, all variants are exported; when specified, only the matching platform is included.
- **Always gzip-compress layers**: Layers are always gzip-compressed in the OCI layout regardless of their state in the Docker save tar, ensuring consistency with OCI conventions.
- **Maximum reuse**: `push_image()` creates a temporary OCI layout via `export_image()` then delegates to the existing `push_layout()` — no new network code needed.
- **Early validation**: Output path is validated before contacting Docker daemon, with clear error messages.
- **Clean error messages**: Docker API raw HTTP URLs are stripped from user-facing errors; actionable hints are provided instead.

## Testing

All 37 new tests pass. All tests mock the Docker SDK — no running daemon required.

Closes #41
