### PR TITLE
Add GitHub Actions workflow to publish to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
+      actions: read
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ">=3.10"
+
+      - name: Install build dependencies
+        run: pip install build twine
+
+      - name: Validate version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Verify distributions
+        run: twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ">=3.10"
+          python-version: ">=3.11"
 
       - name: Install build dependencies
         run: pip install build twine

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,59 @@
-# Setting Up Your Environment
+# Contributing to RegShape
 
-## Setting Up Visual Studio Code
+## Setting Up Your Environment
+
+### Setting Up Visual Studio Code
 Create an `.env` file in the root directory of the project and add the following:
 ```
 PYTHONPATH=<your_workspace_folder_path>/src
 ```
+
+## Releasing
+
+### Version Tagging Convention
+
+Release tags follow the format `vX.Y.Z` (e.g., `v0.1.0`, `v1.0.0`). The version
+in the tag **must** match the `version` field in `pyproject.toml`.
+
+### How to Create a Release
+
+1. Update the `version` field in `pyproject.toml` to the new version.
+2. Commit the version bump: `git commit -am "Bump version to X.Y.Z"`.
+3. Push the commit to `main`.
+4. Create a GitHub Release:
+   - Go to **Releases** → **Draft a new release**.
+   - Create a new tag `vX.Y.Z` targeting `main`.
+   - Add release notes describing the changes.
+   - Click **Publish release**.
+5. The `publish.yml` workflow runs automatically, building and publishing the
+   package to PyPI.
+
+### What the Workflow Does
+
+The `publish.yml` GitHub Actions workflow:
+
+1. **Build** — Checks out the code, validates the tag version matches
+   `pyproject.toml`, builds sdist and wheel distributions, and verifies them
+   with `twine check`.
+2. **Publish** — Downloads the build artifacts and publishes to PyPI using
+   trusted publishing (OIDC).
+
+### Verifying the Published Package
+
+After the workflow completes, verify the package at
+https://pypi.org/project/regshape/. You can also install it with:
+
+```
+pip install regshape==X.Y.Z
+```
+
+### Trusted Publishing Setup (One-Time)
+
+PyPI trusted publishing must be configured once by the repository owner:
+
+1. On [PyPI](https://pypi.org/), go to **Account** → **Publishing** → **Add a
+   new pending publisher**.
+2. Fill in: Owner = `toddysm`, Repository = `regshape`, Workflow = `publish.yml`,
+   Environment = `pypi`.
+3. On GitHub, create an environment named `pypi` under **Settings** →
+   **Environments**. Optionally add required reviewers for an approval gate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,29 @@ description = "CLI tool and Python library for manipulating artifacts in OCI reg
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
+authors = [
+    { name = "Toddy Mladenov" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Libraries",
+]
 dependencies = [
     "click>=8.1.0",
     "requests>=2.31.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/toddysm/regshape"
+Repository = "https://github.com/toddysm/regshape"
+"Bug Tracker" = "https://github.com/toddysm/regshape/issues"
 
 [project.scripts]
 regshape = "regshape.cli.main:regshape"


### PR DESCRIPTION
## Summary

Implements a GitHub Actions workflow that builds, packages, and publishes the `regshape` Python package to PyPI on tagged releases.

## Changes

### `.github/workflows/publish.yml` (new)
- **Build job**: checks out code, sets up Python 3.10+, validates tag version matches `pyproject.toml`, builds sdist and wheel, verifies with `twine check`, uploads artifacts
- **Publish job**: downloads build artifacts and publishes to PyPI using trusted publishing (OIDC) — no API token secrets needed

### `pyproject.toml`
- Added `authors` field
- Added `classifiers` (Development Status, License, Python versions, OS, Topic)
- Added `[project.urls]` (Homepage, Repository, Bug Tracker)

### `CONTRIBUTING.md`
- Added "Releasing" section documenting:
  - Tag naming convention (`vX.Y.Z`)
  - Step-by-step release process
  - What the workflow does
  - How to verify the published package
  - One-time trusted publishing setup instructions

## Manual Setup Required
- Configure trusted publishing on PyPI (pending publisher: owner=`toddysm`, repo=`regshape`, workflow=`publish.yml`, environment=`pypi`)
- Create a `pypi` environment in GitHub repo Settings → Environments

Closes #50
Closes #51
