### PR TITLE
Fix missing docker runtime dependency (0.1.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "regshape"
-version = "0.1.0"
+version = "0.1.1"
 description = "CLI tool and Python library for manipulating artifacts in OCI registries"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -25,7 +25,13 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.1.0",
+    "docker>=7.1.0",
     "requests>=2.31.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9.0.3",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Problem

Running `regshape` after `pip install regshape` from PyPI fails with:

```
ModuleNotFoundError: No module named 'docker'
```

The `docker` package is imported by `regshape.libs.docker.operations` but it was not declared as a runtime dependency in `pyproject.toml`. It was only listed in `requirements.txt`, which is used for local development environments and does not influence the metadata of the published wheel.

## Fix

- Add `docker>=7.1.0` to `[project].dependencies` in `pyproject.toml`.
- Move `pytest` into a new `[project.optional-dependencies]` `dev` extra so it stays out of the runtime metadata (installable via `pip install 'regshape[dev]'`).
- Bump version to `0.1.1` (PyPI does not allow re-uploading `0.1.0`).

## Release plan

After this PR is merged, cut a `v0.1.1` release and trigger the `Publish to PyPI` workflow.